### PR TITLE
Add delegates outside of the Worker using a :via flag

### DIFF
--- a/lib/cachex/stats/registry.ex
+++ b/lib/cachex/stats/registry.ex
@@ -82,7 +82,7 @@ defmodule Cachex.Stats.Registry do
 
   # Both the get_and_update and increment calls do either an update or a set depending on whether
   # the key existed in the cache before the operation.
-  defp process_action(action, { status, _value }) when action in [ :get_and_update, :incr ] do
+  defp process_action(action, { status, _value }) when action in [ :get_and_update, :decr, :incr ] do
     [ { action, status, 1 }, { :global, status == :ok && :updateCount || :setCount, 1 } ]
   end
 

--- a/lib/cachex/worker/local.ex
+++ b/lib/cachex/worker/local.ex
@@ -10,9 +10,6 @@ defmodule Cachex.Worker.Local do
   # from inside this module (internal functions), you should go through the
   # Worker parent module to avoid creating potentially messy internal dependency.
 
-  # no notify opts
-  @no_notify [ notify: false ]
-
   # add some aliases
   alias Cachex.Util
   alias Cachex.Worker
@@ -99,7 +96,7 @@ defmodule Cachex.Worker.Local do
   of records which were removed.
   """
   def clear(state, _options) do
-    eviction_count = case Worker.size(state, @no_notify) do
+    eviction_count = case Worker.size(state, notify: false) do
       { :ok, size } -> size
       _other_value_ -> nil
     end
@@ -155,7 +152,7 @@ defmodule Cachex.Worker.Local do
 
     exists_key =
       state
-      |> Worker.quietly_exists?(key)
+      |> Worker.exists?(key, notify: false)
 
     new_value =
       state.cache

--- a/lib/cachex/worker/transactional.ex
+++ b/lib/cachex/worker/transactional.ex
@@ -8,9 +8,6 @@ defmodule Cachex.Worker.Transactional do
   # As such these implementations are far slower than others, but provide a good
   # level of consistency across nodes.
 
-  # no notify opts
-  @no_notify [ notify: false ]
-
   # add some aliases
   alias Cachex.Util
   alias Cachex.Worker
@@ -79,7 +76,7 @@ defmodule Cachex.Worker.Transactional do
   """
   def update(state, key, value, _options) do
     state
-    |> Worker.get_and_update(key, fn(_val) -> value end, @no_notify)
+    |> Worker.get_and_update(key, fn(_val) -> value end, notify: false)
     |> (&(Util.create_truthy_result(elem(&1, 0) == :ok))).()
   end
 
@@ -99,7 +96,7 @@ defmodule Cachex.Worker.Transactional do
   `size/1` in order to return the number of records which were removed.
   """
   def clear(state, _options) do
-    eviction_count = case Worker.size(state, @no_notify) do
+    eviction_count = case Worker.size(state, notify: false) do
       { :ok, size } -> size
       _other_value_ -> nil
     end
@@ -149,7 +146,7 @@ defmodule Cachex.Worker.Transactional do
     Worker.get_and_update(state, key, fn
       (nil) -> initial + amount
       (val) -> val + amount
-    end, @no_notify)
+    end, notify: false)
   end
 
   @doc """
@@ -184,7 +181,7 @@ defmodule Cachex.Worker.Transactional do
       end
 
       if value != nil do
-        Worker.del(state, key, @no_notify)
+        Worker.del(state, key, notify: false)
       end
 
       value

--- a/test/cachex_test/stats/registry/local.exs
+++ b/test/cachex_test/stats/registry/local.exs
@@ -33,6 +33,25 @@ defmodule CachexTest.Stats.Registry.Local do
     assert(stats[:global] == %{ opCount: 1 })
   end
 
+  test "stats with an decr action", state do
+    set_result = Cachex.set(state.cache, "key", 1)
+    assert(set_result == { :ok, true })
+
+    decr_result = Cachex.decr(state.cache, "key")
+    assert(decr_result == { :ok, 0 })
+
+    decr_result = Cachex.decr(state.cache, "missing_key")
+    assert(decr_result == { :missing, -1 })
+
+    { status, stats } = Cachex.stats(state.cache, for: :raw)
+
+    assert(status == :ok)
+    assert(stats[:decr] == %{ ok: 1, missing: 1 })
+    # setCount is 2 because missing keys are set
+    # updateCount is 1 because only :ok is an update
+    assert(stats[:global] == %{ opCount: 3, setCount: 2, updateCount: 1 })
+  end
+
   test "stats with a del action", state do
     set_result = Cachex.set(state.cache, "key", "value")
     assert(set_result == { :ok, true })

--- a/test/cachex_test/stats/registry/remote.exs
+++ b/test/cachex_test/stats/registry/remote.exs
@@ -33,6 +33,25 @@ defmodule CachexTest.Stats.Registry.Remote do
     assert(stats[:global] == %{ opCount: 1 })
   end
 
+  test "stats with an decr action", state do
+    set_result = Cachex.set(state.cache, "key", 1)
+    assert(set_result == { :ok, true })
+
+    decr_result = Cachex.decr(state.cache, "key")
+    assert(decr_result == { :ok, 0 })
+
+    decr_result = Cachex.decr(state.cache, "missing_key")
+    assert(decr_result == { :missing, -1 })
+
+    { status, stats } = Cachex.stats(state.cache, for: :raw)
+
+    assert(status == :ok)
+    assert(stats[:decr] == %{ ok: 1, missing: 1 })
+    # setCount is 2 because missing keys are set
+    # updateCount is 1 because only :ok is an update
+    assert(stats[:global] == %{ opCount: 3, setCount: 2, updateCount: 1 })
+  end
+
   test "stats with a del action", state do
     set_result = Cachex.set(state.cache, "key", "value")
     assert(set_result == { :ok, true })

--- a/test/cachex_test/stats/registry/transactional.exs
+++ b/test/cachex_test/stats/registry/transactional.exs
@@ -33,6 +33,25 @@ defmodule CachexTest.Stats.Registry.Transactional do
     assert(stats[:global] == %{ opCount: 1 })
   end
 
+  test "stats with an decr action", state do
+    set_result = Cachex.set(state.cache, "key", 1)
+    assert(set_result == { :ok, true })
+
+    decr_result = Cachex.decr(state.cache, "key")
+    assert(decr_result == { :ok, 0 })
+
+    decr_result = Cachex.decr(state.cache, "missing_key")
+    assert(decr_result == { :missing, -1 })
+
+    { status, stats } = Cachex.stats(state.cache, for: :raw)
+
+    assert(status == :ok)
+    assert(stats[:decr] == %{ ok: 1, missing: 1 })
+    # setCount is 2 because missing keys are set
+    # updateCount is 1 because only :ok is an update
+    assert(stats[:global] == %{ opCount: 3, setCount: 2, updateCount: 1 })
+  end
+
   test "stats with a del action", state do
     set_result = Cachex.set(state.cache, "key", "value")
     assert(set_result == { :ok, true })


### PR DESCRIPTION
Based around #8. 

Right now the Worker has the code for various functions which delegate in order to notify hooks correctly. With this PR we can delegate in the main interface and maintain the hook notifications using `:via`. 

The example from the issue is if you call something like `Cachex.incr(:my_cache, "key", via: :decr)`, it notifies using `{ :decr, "key" }`. After this PR is merged, this will function correctly. The same implementation exists for both `expire_at/4` and `persist/3`.