### PR TITLE
Ensure nodes can reconnect after dropping out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,12 @@ otp_release:
   - 18.2
   - 18.1
   - 18.0
+before_script:
+  - epmd -daemon
 script:
-  - mix test --trace
+  - mix cachex.test --trace
 after_success:
-  - mix coveralls.travis
+  - mix cachex.coveralls.travis
+branches:
+  only:
+    - master

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ If you feel something can be improved, or have any questions about certain behav
 If you *do* make changes to the codebase, please make sure you test your changes thoroughly, and include any unit tests alongside new or changed behaviours. Cachex currently uses the excellent [excoveralls](https://github.com/parroty/excoveralls) to track code coverage.
 
 ```elixir
-$ mix test --trace
-$ mix coveralls
-$ mix coveralls.html && open cover/excoveralls.html
+$ mix cachex.test
+$ mix cachex.coveralls
+$ mix cachex.coveralls.html && open cover/excoveralls.html
 ```

--- a/coveralls.json
+++ b/coveralls.json
@@ -11,14 +11,15 @@
     "^\\s+use\\s+"
   ],
   "custom_stop_words": [
-    "defwrap.+(.+\\\\.+),?"
+    "defwrap.+"
   ],
   "coverage_options": {
     "treat_no_relevant_lines_as_covered": true
   },
   "skip_files": [
     "lib/cachex/macros.ex",
-    "lib/cachex/macros/boilerplate.ex",
-    "lib/cachex/macros/gen_server.ex"
+    "lib/cachex/macros/*",
+    "lib/mix/cachex.ex",
+    "lib/mix/tasks/*",
   ]
 }

--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -8,6 +8,7 @@ defmodule Cachex do
 
   # add some aliases
   alias Cachex.Inspector
+  alias Cachex.Janitor
   alias Cachex.Options
   alias Cachex.Util
   alias Cachex.Worker
@@ -46,7 +47,8 @@ defmodule Cachex do
   @type status :: :ok | :error | :missing
 
   @doc """
-  Initialize the Mnesia table and supervision tree for this cache.
+  Initialize the Mnesia table and supervision tree for this cache, linking the
+  cache to the current process.
 
   We also allow the user to define their own options for the cache. We start a
   Supervisor to look after all internal workers backing the cache, in order to
@@ -156,11 +158,25 @@ defmodule Cachex do
   """
   @spec start_link(options, options) :: { atom, pid }
   def start_link(options \\ [], supervisor_options \\ []) do
-    with { :ok, true } <- ensure_not_started(options[:name]),
-         { :ok, opts } <- parse_options(options),
-         { :ok, true } <- ensure_connection(opts),
-         { :ok, true } <- start_table(opts),
-     do: Supervisor.start_link(__MODULE__, opts, supervisor_options)
+    with { :ok, opts } <- setup_env(options) do
+      Supervisor.start_link(__MODULE__, opts, supervisor_options)
+    end
+  end
+
+  @doc """
+  Initialize the Mnesia table and supervision tree for this cache, without linking
+  the cache to the current process.
+
+  Supports all the same options as `start_link/2`. This is mainly used for testing
+  in order to keep caches around when processes may be torn down.
+  """
+  @spec start(options) :: { atom, pid }
+  def start(options \\ []) do
+    with { :ok, opts } <- setup_env(options) do
+      Janitor.start(opts, [ name: opts.janitor ])
+      Worker.start(opts, [ name: opts.cache ])
+      { :ok, self }
+    end
   end
 
   @doc false
@@ -172,11 +188,11 @@ defmodule Cachex do
   def init(%Options{ } = options) do
     ttl_workers = case options.ttl_interval do
       nil -> []
-      _other -> [worker(Cachex.Janitor, [options])]
+      _other -> [worker(Janitor, [options, [ name: options.janitor ]])]
     end
 
     children = ttl_workers ++ [
-      worker(Cachex.Worker, [options, [name: options.cache]])
+      worker(Worker, [options, [ name: options.cache ]])
     ]
 
     supervise(children, strategy: :one_for_one)
@@ -1132,6 +1148,18 @@ defmodule Cachex do
   # it in tuple just to avoid compiler warnings when using it with the `with` block.
   defp parse_options(options) when is_list(options),
   do: { :ok, Options.parse(options) }
+
+  # Runs through the initial setup for a cache, parsing a list of options into
+  # a set of Cachex options, before adding the node to any remote nodes and then
+  # setting up the local table. This is separated out as it's required in both
+  # `start_link/2` and `start/1`.
+  defp setup_env(options) when is_list(options) do
+    with { :ok, true } <- ensure_not_started(options[:name]),
+         { :ok, opts } <- parse_options(options),
+         { :ok, true } <- ensure_connection(opts),
+         { :ok, true } <- start_table(opts),
+     do: { :ok, opts }
+  end
 
   # Starts up an Mnesia table based on the provided options. If an error occurs
   # when setting up the table, we return an error tuple to represent the issue.

--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -376,7 +376,7 @@ defmodule Cachex do
   @spec abort(cache, any, options) :: Exception
   defwrap abort(cache, reason, options \\ []) when is_list(options) do
     do_action(cache, fn(_) ->
-      :mnesia.is_transaction && :mnesia.abort(reason)
+      { :ok, :mnesia.is_transaction && :mnesia.abort(reason) }
     end)
   end
 

--- a/lib/cachex/connection.ex
+++ b/lib/cachex/connection.ex
@@ -1,0 +1,43 @@
+defmodule Cachex.Connection do
+  @moduledoc false
+  # Module to handle the connections between remote Cachex nodes and to enforce
+  # replication and synchronicity between the nodes. Currently this module is
+  # rather small, but has been separated out in anticipation of further work.
+
+  # alias options
+  alias Cachex.Options
+
+  @doc """
+  Small module for handling the remote connections and rejoining a Cachex set of
+  remote nodes. We go through all supposed connected nodes and ping them to ensure
+  they're reachable - we then RPC to one of the online nodes to add the current
+  node to Mnesia. This will sync up the nodes and replication, and bring the node
+  back into the cluster.
+  """
+  def ensure_connection(%Options{ cache: cache, nodes: nodes }) do
+    case find_online_nodes(nodes) do
+      [] -> { :ok, true }
+      li -> { :ok, reconnect_node(cache, li, node) || true }
+    end
+  end
+
+  # Searches a list of nodes to find those which are online (i.e. those which
+  # return :pong when pinged). We filter out the local node name to avoid pinging
+  # ourselves unnecessarily.
+  defp find_online_nodes(nodes) do
+    nodes
+    |> Enum.filter(&(is_atom(&1)))
+    |> Enum.filter(&(&1 != node()))
+    |> Enum.filter(&(:net_adm.ping(&1) == :pong))
+  end
+
+  # Loops through a list of nodes and attempts to reconnect to this node from that
+  # node. We do it this way as the other nodes can safely replicate to this node
+  # before we create our local tables - ensuring consistency.
+  defp reconnect_node(cache, nodes, node) do
+    Enum.any?(nodes, fn(remote_node) ->
+      :rpc.call(remote_node, Cachex, :add_node, [cache, node]) == { :ok, true }
+    end)
+  end
+
+end

--- a/lib/cachex/janitor.ex
+++ b/lib/cachex/janitor.ex
@@ -24,7 +24,18 @@ defmodule Cachex.Janitor do
   with.
   """
   def start_link(options \\ %Cachex.Options { }, gen_options \\ []) do
-    GenServer.start(__MODULE__, options, gen_options)
+    if options.ttl_interval do
+      GenServer.start_link(__MODULE__, options, gen_options)
+    end
+  end
+
+  @doc """
+  Same as `start_link/2` however this function does not link to the calling process.
+  """
+  def start(options \\ %Cachex.Options { }, gen_options \\ []) do
+    if options.ttl_interval do
+      GenServer.start(__MODULE__, options, gen_options)
+    end
   end
 
   @doc """

--- a/lib/cachex/options.ex
+++ b/lib/cachex/options.ex
@@ -49,7 +49,7 @@ defmodule Cachex.Options do
         nil
     end
 
-    remote_node_list = Util.get_opt_list(options, :nodes, [node()])
+    remote_node_list = Enum.uniq([ node | Util.get_opt_list(options, :nodes, [])])
     default_fallback = Util.get_opt_function(options, :default_fallback)
 
     fallback_args =

--- a/lib/cachex/options.ex
+++ b/lib/cachex/options.ex
@@ -12,6 +12,7 @@ defmodule Cachex.Options do
             default_fallback: nil,  # the default fallback implementation
             default_ttl: nil,       # any default ttl values to use
             fallback_args: nil,     # arguments to pass to a cache loader
+            janitor: nil,           # the name of the janitor attached (if any)
             pre_hooks: nil,         # any pre hooks to attach
             post_hooks: nil,        # any post hooks to attach
             nodes: nil,             # a list of nodes to connect to
@@ -49,6 +50,10 @@ defmodule Cachex.Options do
         nil
     end
 
+    janitor = if ttl_interval do
+      Util.janitor_for_cache(cache)
+    end
+
     remote_node_list = Enum.uniq([ node | Util.get_opt_list(options, :nodes, [])])
     default_fallback = Util.get_opt_function(options, :default_fallback)
 
@@ -69,7 +74,7 @@ defmodule Cachex.Options do
           type: :post,
           results: true,
           server_args: [
-            name: Cachex.Util.stats_for_cache(cache)
+            name: Util.stats_for_cache(cache)
           ]
         })
       false ->
@@ -91,6 +96,7 @@ defmodule Cachex.Options do
       "default_fallback": default_fallback,
       "default_ttl": default_ttl,
       "fallback_args": fallback_args,
+      "janitor": janitor,
       "nodes": remote_node_list,
       "pre_hooks": pre_hooks,
       "post_hooks": post_hooks,

--- a/lib/cachex/util.ex
+++ b/lib/cachex/util.ex
@@ -43,6 +43,20 @@ defmodule Cachex.Util do
   end
 
   @doc """
+  Creates a long machine name from a provided binary name. If a hostname is given,
+  it will be used - otherwise we default to using the local node's hostname.
+  """
+  def create_node_name(name, hostname \\ nil)
+  def create_node_name(name, hostname) when is_atom(name),
+  do: name |> to_string |> create_node_name(hostname)
+  def create_node_name(name, hostname) when is_binary(name) do
+    String.to_atom(name <> "@" <> case hostname do
+      nil -> local_hostname()
+      val -> val
+    end)
+  end
+
+  @doc """
   Creates an input record based on a key, value and expiration. If the value
   passed is nil, then we apply any defaults. Otherwise we add the value
   to the current time (in milliseconds) and return a tuple for the table.
@@ -231,6 +245,15 @@ defmodule Cachex.Util do
   """
   def list_to_tuple(list) when is_list(list),
   do: Enum.reduce(list, {}, &(Tuple.append(&2, &1)))
+
+  @doc """
+  Retrieves the local hostname of this node.
+  """
+  def local_hostname do
+    :inet.gethostname
+    |> elem(1)
+    |> to_string
+  end
 
   @doc """
   Returns a selection to return the designated value for all rows. Enables things

--- a/lib/cachex/util.ex
+++ b/lib/cachex/util.ex
@@ -30,6 +30,12 @@ defmodule Cachex.Util do
   def reply(value, state), do: { :reply, value, state }
 
   @doc """
+  Appends a string to an atom and returns as an atom.
+  """
+  def atom_append(atom, suffix),
+  do: String.to_atom(to_string(atom) <> suffix)
+
+  @doc """
   Converts a number of memory bytes to a binary representation.
   """
   def bytes_to_readable(size),
@@ -229,6 +235,13 @@ defmodule Cachex.Util do
   end
 
   @doc """
+  Very small handler for appending "_janitor" to the name of a cache in order to
+  create the name of a Janitor automatically.
+  """
+  def janitor_for_cache(cache) when is_atom(cache),
+  do: atom_append(cache, "_janitor")
+
+  @doc """
   Retrieves the last item in a Tuple. This is just shorthand around sizeof and
   pulling the last element.
   """
@@ -280,7 +293,7 @@ defmodule Cachex.Util do
   create the name of a stats hook automatically.
   """
   def stats_for_cache(cache) when is_atom(cache),
-  do: String.to_atom(to_string(cache) <> "_stats")
+  do: atom_append(cache, "_stats")
 
   @doc """
   Very small unwrapper for an Mnesia start result. We accept already started tables

--- a/lib/cachex/worker.ex
+++ b/lib/cachex/worker.ex
@@ -30,6 +30,13 @@ defmodule Cachex.Worker do
   with.
   """
   def start_link(options \\ %Cachex.Options { }, gen_options \\ []) do
+    GenServer.start_link(__MODULE__, options, gen_options)
+  end
+
+  @doc """
+  Same as `start_link/2` however this function does not link to the calling process.
+  """
+  def start(options \\ %Cachex.Options { }, gen_options \\ []) do
     GenServer.start(__MODULE__, options, gen_options)
   end
 

--- a/lib/cachex/worker.ex
+++ b/lib/cachex/worker.ex
@@ -343,7 +343,31 @@ defmodule Cachex.Worker do
   @doc """
   Very tiny wrapper to retrieve the current state of a cache
   """
-  defcall state, do: state
+  def handle_call({ :state }, _ctx, state),
+  do: { :reply, state, state }
+
+  @doc """
+  Handler for adding a node to the worker, to ensure that we use the correct
+  actions.
+  """
+  def handle_call({ :add_node, node }, _ctx, state) do
+    new_options = %Options{ state.options |
+      remote: true,
+      nodes: if Enum.member?(state.options.nodes, node) do
+        state.options.nodes
+      else
+        [node|state.options.nodes]
+      end
+    }
+
+    new_state = if state.options.transactional do
+      %__MODULE__{ state | options: new_options }
+    else
+      %__MODULE__{ state | actions: __MODULE__.Remote, options: new_options }
+    end
+
+    { :reply, new_state, new_state }
+  end
 
   ###
   # Functions designed to only be used internally (i.e. those not forwarded to

--- a/lib/mix/cachex.ex
+++ b/lib/mix/cachex.ex
@@ -36,9 +36,7 @@ defmodule Mix.Cachex do
   Small handler to stop the slave nodes, simply iterating the names of the nodes
   and terminating them.
   """
-  def stop do
-    Enum.each(@nodenames, &stop_node/1)
-  end
+  def stop, do: Enum.each(@nodenames, &stop_node/1)
 
   @doc """
   Convenience handler for executing a given function without having to start/stop
@@ -50,6 +48,13 @@ defmodule Mix.Cachex do
     task.()
     stop()
   end
+
+  @doc """
+  Runs a task in a node context. Opens up a node context and runs the given task
+  name with the given task args. This is just shorthand for convenience.
+  """
+  def run_in_context(task, args) when is_binary(task),
+  do: run_task(fn -> Mix.Task.run(task, args) end)
 
   # Starts a local node using the :slave module.
   defp start_node(node) do

--- a/lib/mix/cachex.ex
+++ b/lib/mix/cachex.ex
@@ -23,9 +23,8 @@ defmodule Mix.Cachex do
     :net_kernel.start([ :cachex_base_node, :shortnames ])
 
     Enum.each(@nodenames, fn(node) ->
-      stop_node(node)
+      stop_node(node) && start_node(node)
 
-      :ct_slave.start(node)
       :net_adm.ping(node)
 
       :rpc.call(node, :mnesia, :start, [])
@@ -52,17 +51,18 @@ defmodule Mix.Cachex do
     stop()
   end
 
-  # Stops a local node - shorthand binding because we stop nodes both before and
-  # after tasks are run. We have to do some fun stuff to split up the host because
-  # otherwise we end up with @host@host as a suffix.
-  defp stop_node(node) do
+  # Starts a local node using the :slave module.
+  defp start_node(node) do
     [ name, host ] =
       node
       |> Kernel.to_string
       |> String.split("@", parts: 2)
       |> Enum.map(&String.to_atom/1)
 
-    :ct_slave.stop(host, name)
+    :slave.start_link(host, name)
   end
+
+  # Stops a local node using the :slave module.
+  defdelegate stop_node(node), to: :slave, as: :stop
 
 end

--- a/lib/mix/cachex.ex
+++ b/lib/mix/cachex.ex
@@ -1,0 +1,68 @@
+defmodule Mix.Cachex do
+  @moduledoc false
+  # A utility lib for binding all required slave nodes. Provides options to start
+  # and stop any required slave nodes, denoted by `@nodenames`. Also provides a
+  # `run_task/1` interface which will run the provided function in the scope of
+  # bound nodes.
+
+  # import utils
+  import Cachex.Util
+
+  # our list of nodes to create, based on tests
+  @nodenames [
+    create_node_name("cachex_test")
+  ]
+
+  @doc """
+  A small handler to bind any slave nodes to this Mix setup. We first name this
+  node as Mix doesn't set itself up with a node name. Then we iterate through all
+  node names and start a `ct_slave`. From that point we ensure that Mnesia is
+  started on each slave node, and that the Cachex module is available to the node.
+  """
+  def start do
+    :net_kernel.start([ :cachex_base_node, :shortnames ])
+
+    Enum.each(@nodenames, fn(node) ->
+      stop_node(node)
+
+      :ct_slave.start(node)
+      :net_adm.ping(node)
+
+      :rpc.call(node, :mnesia, :start, [])
+      :rpc.call(node, :code, :add_paths, [:code.get_path])
+    end)
+  end
+
+  @doc """
+  Small handler to stop the slave nodes, simply iterating the names of the nodes
+  and terminating them.
+  """
+  def stop do
+    Enum.each(@nodenames, &stop_node/1)
+  end
+
+  @doc """
+  Convenience handler for executing a given function without having to start/stop
+  any required nodes. Simply starts all nodes, executes the function, and then
+  closes all nodes.
+  """
+  def run_task(task) when is_function(task) do
+    start()
+    task.()
+    stop()
+  end
+
+  # Stops a local node - shorthand binding because we stop nodes both before and
+  # after tasks are run. We have to do some fun stuff to split up the host because
+  # otherwise we end up with @host@host as a suffix.
+  defp stop_node(node) do
+    [ name, host ] =
+      node
+      |> Kernel.to_string
+      |> String.split("@", parts: 2)
+      |> Enum.map(&String.to_atom/1)
+
+    :ct_slave.stop(host, name)
+  end
+
+end

--- a/lib/mix/tasks/cachex.coveralls.ex
+++ b/lib/mix/tasks/cachex.coveralls.ex
@@ -11,11 +11,8 @@ defmodule Mix.Tasks.Cachex.Coveralls do
   Binds all slave nodes and starts off the `coveralls` task.
   """
   @spec run(OptionParser.argv) :: no_return
-  def run(args) do
-    Mix.Cachex.run_task(fn ->
-      Mix.Task.run("coveralls", args)
-    end)
-  end
+  def run(args),
+  do: Mix.Cachex.run_in_context("coveralls", args)
 
   # Detail binding
   defmodule Detail do
@@ -30,11 +27,8 @@ defmodule Mix.Tasks.Cachex.Coveralls do
     Binds all slave nodes and starts off the `coveralls.detail` task.
     """
     @spec run(OptionParser.argv) :: no_return
-    def run(args) do
-      Mix.Cachex.run_task(fn ->
-        Mix.Task.run("coveralls.detail", args)
-      end)
-    end
+    def run(args),
+    do: Mix.Cachex.run_in_context("coveralls.detail", args)
 
   end
 
@@ -50,11 +44,8 @@ defmodule Mix.Tasks.Cachex.Coveralls do
     Binds all slave nodes and starts off the `coveralls.html` task.
     """
     @spec run(OptionParser.argv) :: no_return
-    def run(args) do
-      Mix.Cachex.run_task(fn ->
-        Mix.Task.run("coveralls.html", args)
-      end)
-    end
+    def run(args),
+    do: Mix.Cachex.run_in_context("coveralls.html", args)
 
   end
 
@@ -70,11 +61,8 @@ defmodule Mix.Tasks.Cachex.Coveralls do
     Binds all slave nodes and starts off the `coveralls.travis` task.
     """
     @spec run(OptionParser.argv) :: no_return
-    def run(args) do
-      Mix.Cachex.run_task(fn ->
-        Mix.Task.run("coveralls.travis", args)
-      end)
-    end
+    def run(args),
+    do: Mix.Cachex.run_in_context("coveralls.travis", args)
 
   end
 

--- a/lib/mix/tasks/cachex.coveralls.ex
+++ b/lib/mix/tasks/cachex.coveralls.ex
@@ -1,0 +1,81 @@
+defmodule Mix.Tasks.Cachex.Coveralls do
+  # inherit mix
+  use Mix.Task
+
+  @moduledoc false
+  # A small binding module for running coverage - spinning up and slave nodes as
+  # required for remote testing. Providing a Mix task for this means that the
+  # user doesn't have to care about setting up any node instances.
+
+  @doc """
+  Binds all slave nodes and starts off the `coveralls` task.
+  """
+  @spec run(OptionParser.argv) :: no_return
+  def run(args) do
+    Mix.Cachex.run_task(fn ->
+      Mix.Task.run("coveralls", args)
+    end)
+  end
+
+  # Detail binding
+  defmodule Detail do
+    # inherit mix
+    use Mix.Task
+
+    @moduledoc false
+    # A small binding module for generating detailed coverage reports with bound
+    # nodes.
+
+    @doc """
+    Binds all slave nodes and starts off the `coveralls.detail` task.
+    """
+    @spec run(OptionParser.argv) :: no_return
+    def run(args) do
+      Mix.Cachex.run_task(fn ->
+        Mix.Task.run("coveralls.detail", args)
+      end)
+    end
+
+  end
+
+  # HTML binding
+  defmodule Html do
+    # inherit mix
+    use Mix.Task
+
+    @moduledoc false
+    # A small binding module for generating HTML coverage reports with bound nodes.
+
+    @doc """
+    Binds all slave nodes and starts off the `coveralls.html` task.
+    """
+    @spec run(OptionParser.argv) :: no_return
+    def run(args) do
+      Mix.Cachex.run_task(fn ->
+        Mix.Task.run("coveralls.html", args)
+      end)
+    end
+
+  end
+
+  # Travis binding
+  defmodule Travis do
+    # inherit mix
+    use Mix.Task
+
+    @moduledoc false
+    # A small binding module for generating CI coverage reports with bound nodes.
+
+    @doc """
+    Binds all slave nodes and starts off the `coveralls.travis` task.
+    """
+    @spec run(OptionParser.argv) :: no_return
+    def run(args) do
+      Mix.Cachex.run_task(fn ->
+        Mix.Task.run("coveralls.travis", args)
+      end)
+    end
+
+  end
+
+end

--- a/lib/mix/tasks/cachex.test.ex
+++ b/lib/mix/tasks/cachex.test.ex
@@ -12,10 +12,7 @@ defmodule Mix.Tasks.Cachex.Test do
   ensured that all slave nodes are started using `Mix.Cachex.run_task/2`.
   """
   @spec run(OptionParser.argv) :: no_return
-  def run(args) do
-    Mix.Cachex.run_task(fn ->
-      Mix.Task.run("test", args)
-    end)
-  end
+  def run(args),
+  do: Mix.Cachex.run_in_context("test", args)
 
 end

--- a/lib/mix/tasks/cachex.test.ex
+++ b/lib/mix/tasks/cachex.test.ex
@@ -1,0 +1,21 @@
+defmodule Mix.Tasks.Cachex.Test do
+  # inherit mix tasks
+  use Mix.Task
+
+  @moduledoc false
+  # A small binding module for running tests - spinning up and slave nodes as
+  # required for remote testing. Providing a Mix task for this means that the
+  # user doesn't have to care about setting up any node instances.
+
+  @doc """
+  Quite simply spawns off a Mix Task to run all tests, after having bound and
+  ensured that all slave nodes are started using `Mix.Cachex.run_task/2`.
+  """
+  @spec run(OptionParser.argv) :: no_return
+  def run(args) do
+    Mix.Cachex.run_task(fn ->
+      Mix.Task.run("test", args)
+    end)
+  end
+
+end

--- a/mix.exs
+++ b/mix.exs
@@ -35,10 +35,11 @@ defmodule Cachex.Mixfile do
         tool: ExCoveralls
       ],
       preferred_cli_env: [
-        "coveralls": :test,
-        "coveralls.detail": :test,
-        "coveralls.html": :test,
-        "coveralls.travis": :test
+        "cachex.test": :test,
+        "cachex.coveralls": :test,
+        "cachex.coveralls.detail": :test,
+        "cachex.coveralls.html": :test,
+        "cachex.coveralls.travis": :test
       ]
     ]
   end

--- a/test/cachex_test.exs
+++ b/test/cachex_test.exs
@@ -1,8 +1,15 @@
 defmodule CachexTest do
   use PowerAssert
 
+  @testhost Cachex.Util.create_node_name("cachex_test")
+
   setup do
-    { :ok, cache: TestHelper.create_cache(), name: String.to_atom(TestHelper.gen_random_string_of_length(16)) }
+    name =
+      16
+      |> TestHelper.gen_random_string_of_length
+      |> String.to_atom
+
+    { :ok, cache: TestHelper.create_cache(), name: name }
   end
 
   test "starting a cache with an invalid name", _state do
@@ -30,8 +37,8 @@ defmodule CachexTest do
   end
 
   test "starting a cache over an invalid mnesia table", state do
-    start_result = Cachex.start_link([name: state.name, nodes: ["failnode@testhost.com"]])
-    assert(start_result == { :error, "Mnesia table setup failed due to {:aborted, {:bad_type, :#{state.name}, \"failnode@testhost.com\"}}" })
+    start_result = Cachex.start_link([name: state.name, ets_opts: [{ :yolo, true }]])
+    assert(start_result == { :error, "Mnesia table setup failed due to {:aborted, {:system_limit, :#{state.name}, {'Failed to create ets table', :badarg}}}" })
   end
 
   test "defwrap macro cannot accept non-atom or non-worker caches", _state do
@@ -48,6 +55,107 @@ defmodule CachexTest do
 
     assert_raise(Cachex.ExecutionError, "Invalid cache provided, got: \"test\"", fn ->
       Cachex.get!("test", "key")
+    end)
+  end
+
+  test "joining an existing remote cluster", state do
+    cache_args = [name: state.name, nodes: [ node(), @testhost ] ]
+
+    { rpc_status, rpc_result } = :rpc.block_call(@testhost, Cachex, :start_link, [cache_args,[]])
+
+    assert(rpc_status == :ok)
+    assert(is_pid(rpc_result))
+
+    set_result = :rpc.block_call(@testhost, Cachex, :set, [state.name, "remote_key_test", "remote_value"])
+
+    assert(set_result == { :ok, true })
+
+    cache = TestHelper.create_cache(cache_args ++ [name: state.name])
+
+    get_result = Cachex.get(cache, "remote_key_test")
+
+    assert(get_result == { :ok, "remote_value" })
+  end
+
+  test "adding a node to an existing cache", state do
+    worker = Cachex.inspect!(state.cache, :state)
+
+    assert(worker.actions == Cachex.Worker.Local)
+    assert(worker.options.nodes == [node])
+
+    add_result = Cachex.add_node(state.cache, @testhost)
+
+    assert(add_result == { :ok, true })
+
+    worker = Cachex.inspect!(state.cache, :state)
+
+    assert(worker.actions == Cachex.Worker.Remote)
+    assert(worker.options.nodes == [@testhost, node])
+  end
+
+  test "adding a node twice to an existing cache", state do
+    worker = Cachex.inspect!(state.cache, :state)
+
+    assert(worker.actions == Cachex.Worker.Local)
+    assert(worker.options.nodes == [node])
+
+    add_result = Cachex.add_node(state.cache, @testhost)
+
+    assert(add_result == { :ok, true })
+
+    add_result = Cachex.add_node(state.cache, @testhost)
+
+    assert(add_result == { :ok, true })
+
+    worker = Cachex.inspect!(state.cache, :state)
+
+    assert(worker.actions == Cachex.Worker.Remote)
+    assert(worker.options.nodes == [@testhost, node])
+  end
+
+  test "adding a node to a transactional cache", _state do
+    cache = TestHelper.create_cache([ transactional: true ])
+
+    worker = Cachex.inspect!(cache, :state)
+
+    assert(worker.actions == Cachex.Worker.Transactional)
+    assert(worker.options.nodes == [node])
+
+    add_result = Cachex.add_node(cache, @testhost)
+
+    assert(add_result == { :ok, true })
+
+    worker = Cachex.inspect!(cache, :state)
+
+    assert(worker.actions == Cachex.Worker.Transactional)
+    assert(worker.options.nodes == [@testhost, node])
+  end
+
+  test "adding a node to an existing cache with a worker", state do
+    worker = Cachex.inspect!(state.cache, :state)
+
+    assert(worker.actions == Cachex.Worker.Local)
+    assert(worker.options.nodes == [node])
+
+    add_result = Cachex.add_node(worker, @testhost)
+
+    assert(add_result == { :ok, true })
+
+    worker = Cachex.inspect!(state.cache, :state)
+
+    assert(worker.actions == Cachex.Worker.Remote)
+    assert(worker.options.nodes == [@testhost, node])
+  end
+
+  test "adding a node using a missing node name", state do
+    add_result = Cachex.add_node(state.cache, :random_missing_node)
+
+    assert(add_result == { :error, "Unable to reach remote node!" })
+  end
+
+  test "adding a node using non-atom", state do
+    assert_raise(FunctionClauseError, fn ->
+      Cachex.add_node(state.cache, "test")
     end)
   end
 

--- a/test/cachex_test.exs
+++ b/test/cachex_test.exs
@@ -61,12 +61,12 @@ defmodule CachexTest do
   test "joining an existing remote cluster", state do
     cache_args = [name: state.name, nodes: [ node(), @testhost ] ]
 
-    { rpc_status, rpc_result } = :rpc.block_call(@testhost, Cachex, :start_link, [cache_args,[]])
+    { rpc_status, rpc_result } = :rpc.block_call(@testhost, Cachex, :start_link, [cache_args])
 
     assert(rpc_status == :ok)
     assert(is_pid(rpc_result))
 
-    set_result = :rpc.block_call(@testhost, Cachex, :set, [state.name, "remote_key_test", "remote_value"])
+    set_result = :rpc.call(@testhost, Cachex, :set, [state.name, "remote_key_test", "remote_value"])
 
     assert(set_result == { :ok, true })
 

--- a/test/cachex_test/abort.exs
+++ b/test/cachex_test/abort.exs
@@ -2,7 +2,7 @@ defmodule CachexTest.Abort do
   use PowerAssert
 
   test "abort does nothing when not in a transaction" do
-    refute(Cachex.abort(%Cachex.Worker{}, :exit))
+    assert(Cachex.abort(%Cachex.Worker{}, :exit) == { :ok, false })
   end
 
   test "abort exits with a given reason when in a transaction" do

--- a/test/cachex_test/util.exs
+++ b/test/cachex_test/util.exs
@@ -213,6 +213,10 @@ defmodule CachexTest.Util do
     refute(Util.has_arity?(&(&1), [3,2]))
   end
 
+  test "util.janitor_for_cache/1 converts a cache name to a janitor name" do
+    assert(Util.janitor_for_cache(:cache) == :cache_janitor)
+  end
+
   test "util.last_of_tuple/1 returns the last value in a tuple" do
     assert(Util.last_of_tuple({ :one, :two, :three }) == :three)
     assert(Util.last_of_tuple({}) == nil)

--- a/test/cachex_test/util.exs
+++ b/test/cachex_test/util.exs
@@ -35,6 +35,25 @@ defmodule CachexTest.Util do
     assert(Util.reply(:value, :test) == { :reply, :value, :test })
   end
 
+  test "util.create_node_name/1 generates a node name on the local host" do
+    nodename = Util.create_node_name("my_name")
+    hostname = :inet.gethostname |> elem(1) |> to_string
+
+    assert(to_string(nodename) == "my_name@#{hostname}")
+  end
+
+  test "util.create_node_name/1 works with an atom name" do
+    nodename = Util.create_node_name(:my_name)
+    hostname = :inet.gethostname |> elem(1) |> to_string
+
+    assert(to_string(nodename) == "my_name@#{hostname}")
+  end
+
+  test "util.create_node_name/1 generates a node name on a given host" do
+    nodename = Util.create_node_name("my_name", "localhost")
+    assert(to_string(nodename) == "my_name@localhost")
+  end
+
   test "util.create_record/3 generates records with no expiration" do
     { cache, key, date, ttl, value } = Util.create_record(%Cachex.Worker{ "cache": :test }, "key", "value")
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -47,6 +47,12 @@ defmodule TestHelper do
     |> Enum.reverse
   end
 
+  def remote_call(node, func, args),
+  do: :rpc.call(node, Cachex, func, args)
+
+  def start_remote_cache(node, args),
+  do: remote_call(node, :start, args)
+
 end
 
 root =

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -10,7 +10,13 @@ defmodule TestHelper do
 
     Cachex.start_link(args ++ [name: table])
 
-    table
+    table_name = args[:name] || table
+
+    ExUnit.Callbacks.on_exit("delete #{table_name}", fn ->
+      :mnesia.delete_table(table_name)
+    end)
+
+    table_name
   end
 
   def gen_random_string_of_length(num) when is_number(num) do


### PR DESCRIPTION
This is based around #12 and corrects several issues in remote caches, namely;

- fixes an issue where caches were not linked to supervisors correctly
- fixes an issue where nodes are not brought into the cluster
- fixes an issue where tables are not replicated across the cluster
- adds a new `add_node/2` function to add a node to a cache at runtime
- adds a new `start/1` function to start a cache without proc linking
- adds new integration tests based around adding remote nodes
