### PR TITLE
Refactor worker implementations around a CRUD interface

### DIFF
--- a/lib/cachex/util.ex
+++ b/lib/cachex/util.ex
@@ -4,32 +4,6 @@ defmodule Cachex.Util do
   # to do with response formatting and generally just common functions.
 
   @doc """
-  Consistency wrapper around current time in millis.
-  """
-  def now, do: :os.system_time(1000)
-
-  @doc """
-  Lazy wrapper for creating an :error tuple.
-  """
-  def error(value), do: { :error, value }
-
-  @doc """
-  Lazy wrapper for creating an :ok tuple.
-  """
-  def ok(value), do: { :ok, value }
-
-  @doc """
-  Lazy wrapper for creating a :noreply tuple.
-  """
-  def noreply(state), do: { :noreply, state }
-  def noreply(_value, state), do: { :noreply, state }
-
-  @doc """
-  Lazy wrapper for creating a :reply tuple.
-  """
-  def reply(value, state), do: { :reply, value, state }
-
-  @doc """
   Appends a string to an atom and returns as an atom.
   """
   def atom_append(atom, suffix),
@@ -82,6 +56,11 @@ defmodule Cachex.Util do
   def create_truthy_result(result) do
     if result, do: ok(true), else: error(false)
   end
+
+  @doc """
+  Lazy wrapper for creating an :error tuple.
+  """
+  def error(value), do: { :error, value }
 
   @doc """
   Retrieves a fallback value for a given key, using either the provided function
@@ -190,14 +169,16 @@ defmodule Cachex.Util do
         |> handle_transaction
     end
   end
-  def handle_transaction({ :atomic, { :error, _ } = err}), do: err
-  def handle_transaction({ :atomic, { :ok, _ } = res}), do: res
-  def handle_transaction({ :atomic, { :loaded, _ } = res}), do: res
-  def handle_transaction({ :atomic, { :missing, _ } = res}), do: res
+  def handle_transaction({ :atomic, { :error, _ } = err }), do: err
+  def handle_transaction({ :atomic, { :ok, _ } = res }), do: res
+  def handle_transaction({ :atomic, { :loaded, _ } = res }), do: res
+  def handle_transaction({ :atomic, { :missing, _ } = res }), do: res
   def handle_transaction({ :atomic, value }), do: ok(value)
   def handle_transaction({ :aborted, reason }), do: error(reason)
   def handle_transaction({ :atomic, _value }, value), do: ok(value)
   def handle_transaction({ :aborted, reason }, _value), do: error(reason)
+  def handle_transaction(fun, pos) when is_function(fun) and is_number(pos),
+  do: fun |> handle_transaction |> elem(pos)
 
   @doc """
   Small utility to figure out if a document has expired based on the last touched
@@ -267,6 +248,27 @@ defmodule Cachex.Util do
     |> elem(1)
     |> to_string
   end
+
+  @doc """
+  Lazy wrapper for creating a :noreply tuple.
+  """
+  def noreply(state), do: { :noreply, state }
+  def noreply(_value, state), do: { :noreply, state }
+
+  @doc """
+  Consistency wrapper around current time in millis.
+  """
+  def now, do: :os.system_time(1000)
+
+  @doc """
+  Lazy wrapper for creating an :ok tuple.
+  """
+  def ok(value), do: { :ok, value }
+
+  @doc """
+  Lazy wrapper for creating a :reply tuple.
+  """
+  def reply(value, state), do: { :reply, value, state }
 
   @doc """
   Returns a selection to return the designated value for all rows. Enables things

--- a/lib/cachex/worker.ex
+++ b/lib/cachex/worker.ex
@@ -422,6 +422,7 @@ defmodule Cachex.Worker do
 
     message = case options[:via] do
       nil -> message
+      val when is_tuple(val) -> val
       val -> put_elem(message, 0, val)
     end
 
@@ -437,7 +438,7 @@ defmodule Cachex.Worker do
     if notify do
       case state.options.post_hooks do
         [] -> nil;
-        li -> Notifier.notify(li, message, result)
+        li -> Notifier.notify(li, message, options[:hook_result] || result)
       end
     end
 

--- a/lib/cachex/worker/local.ex
+++ b/lib/cachex/worker/local.ex
@@ -50,7 +50,7 @@ defmodule Cachex.Worker.Local do
   """
   def update(state, key, changes) do
     state.cache
-    |> :ets.update_element(key, List.wrap(changes))
+    |> :ets.update_element(key, changes)
     |> (&(Util.create_truthy_result/1)).()
   end
 

--- a/lib/cachex/worker/local.ex
+++ b/lib/cachex/worker/local.ex
@@ -14,6 +14,9 @@ defmodule Cachex.Worker.Local do
   alias Cachex.Util
   alias Cachex.Worker
 
+  # define purge constants
+  @purge_override [{ :via, { :purge } }, { :hook_result, { :ok, 1 } }]
+
   @doc """
   Writes a record into the cache, and returns a result signifying whether the
   write was successful or not.
@@ -33,7 +36,7 @@ defmodule Cachex.Worker.Local do
     case :ets.lookup(state.cache, key) do
       [{ _cache, ^key, touched, ttl, _value } = record] ->
         case Util.has_expired?(touched, ttl) do
-          true  -> Worker.del(state, key, via: :purge) && nil
+          true  -> Worker.del(state, key, @purge_override) && nil
           false -> record
         end
       _unrecognised_val ->

--- a/lib/cachex/worker/remote.ex
+++ b/lib/cachex/worker/remote.ex
@@ -14,6 +14,9 @@ defmodule Cachex.Worker.Remote do
   alias Cachex.Util
   alias Cachex.Worker
 
+  # define purge constants
+  @purge_override [{ :via, { :purge } }, { :hook_result, { :ok, 1 } }]
+
   @doc """
   Writes a record into the cache, and returns a result signifying whether the
   write was successful or not.
@@ -33,7 +36,7 @@ defmodule Cachex.Worker.Remote do
     case :mnesia.dirty_read(state.cache, key) do
       [{ _cache, ^key, touched, ttl, _value } = record] ->
         case Util.has_expired?(touched, ttl) do
-          true  -> Worker.del(state, key, via: :purge) && nil
+          true  -> Worker.del(state, key, @purge_override) && nil
           false -> record
         end
       _unrecognised_val ->

--- a/lib/cachex/worker/remote.ex
+++ b/lib/cachex/worker/remote.ex
@@ -15,59 +15,37 @@ defmodule Cachex.Worker.Remote do
   alias Cachex.Worker
 
   @doc """
-  Simply do an Mnesia dirty read on the given key. If the key does not exist we
-  check to see if there's a fallback function. If there is we call it and then
-  set the value into the cache before returning it to the user. Otherwise we
-  simply return a nil value in an ok tuple.
+  Writes a record into the cache, and returns a result signifying whether the
+  write was successful or not.
   """
-  def get(state, key, options) do
-    fb_fun =
-      options
-      |> Util.get_opt_function(:fallback)
-
-    val = case :mnesia.dirty_read(state.cache, key) do
-      [{ _cache, ^key, touched, ttl, value }] ->
-        case Util.has_expired?(touched, ttl) do
-          true  -> Worker.del(state, key); :missing;
-          false -> value
-        end
-      _unrecognised_val -> :missing
-    end
-
-    case val do
-      :missing ->
-        case Util.get_fallback(state, key, fb_fun) do
-          { :ok, new_value } ->
-            { :missing, new_value }
-          { :loaded, new_value } = result ->
-            Worker.set(state, key, new_value)
-            result
-        end
-      val ->
-        { :ok, val }
-    end
-  end
-
-  @doc """
-  Inserts a value into the Mnesia tables, without caring about overwrites. We
-  transform the result into an ok/error tuple to keep consistency in the API.
-  """
-  def set(state, key, value, options) do
-    ttl =
-      options
-      |> Util.get_opt_number(:ttl)
-
-    state
-    |> Util.create_record(key, value, ttl)
-    |> :mnesia.dirty_write
+  def write(state, record) do
+    state.cache
+    |> :mnesia.dirty_write(record)
     |> (&(Util.create_truthy_result(&1 == :ok))).()
   end
 
   @doc """
-  We delegate to the Transactional actions as this function requires both a
-  get/set, and as such it's only safe to do via a transaction.
+  Read back the key from Mnesia, using a dirty read for performance/replication.
+  If the key does not exist we return a `nil` value. If the key has expired, we
+  delete it from the cache using the `:purge` action as a notification.
   """
-  defdelegate update(state, key, value, options),
+  def read(state, key) do
+    case :mnesia.dirty_read(state.cache, key) do
+      [{ _cache, ^key, touched, ttl, _value } = record] ->
+        case Util.has_expired?(touched, ttl) do
+          true  -> Worker.del(state, key, via: :purge) && nil
+          false -> record
+        end
+      _unrecognised_val ->
+        nil
+    end
+  end
+
+  @doc """
+  Updates a number of fields in a record inside the cache, by key. We delegate to
+  the implementation in the Transactional Worker to avoid duplication.
+  """
+  defdelegate update(state, key, changes),
   to: Cachex.Worker.Transactional
 
   @doc """
@@ -75,7 +53,7 @@ defmodule Cachex.Worker.Remote do
   the key exists or not, we return a truthy value (to signify the record is not
   in the cache).
   """
-  def del(state, key, _options) do
+  def delete(state, key) do
     state.cache
     |> :mnesia.dirty_delete(key)
     |> (&(Util.create_truthy_result(&1 == :ok))).()
@@ -86,13 +64,6 @@ defmodule Cachex.Worker.Remote do
   as the behaviour matches between implementations.
   """
   defdelegate clear(state, options),
-  to: Cachex.Worker.Transactional
-
-  @doc """
-  Sets the expiration time on a given key based on the value passed in. We pass
-  this through to the Transactional actions as we require a get/set combination.
-  """
-  defdelegate expire(state, key, expiration, options),
   to: Cachex.Worker.Transactional
 
   @doc """
@@ -114,44 +85,11 @@ defmodule Cachex.Worker.Remote do
   to: Cachex.Worker.Transactional
 
   @doc """
-  Refreshes the internal timestamp on the record to ensure that the TTL only takes
-  place from this point forward. We pass this through to the Transactional actions
-  as we require a get/set combination.
-  """
-  defdelegate refresh(state, key, options),
-  to: Cachex.Worker.Transactional
-
-  @doc """
   This is like `del/2` but it returns the last known value of the key as it
   existed in the cache upon deletion. We delegate to the Transactional actions
   as this requires a potential get/del combination.
   """
   defdelegate take(state, key, options),
   to: Cachex.Worker.Transactional
-
-  @doc """
-  Checks the remaining TTL on a provided key. We do this by retrieving the local
-  record and pulling out the touched and ttl fields. In order to calculate the
-  remaining time, we simply subtract the sum of these numbers from the current
-  time in milliseconds. We return the remaining time to live in an ok tuple. If
-  the key does not exist in the cache, we return an error tuple with a warning.
-  """
-  def ttl(state, key, _options) do
-    case :mnesia.dirty_read(state.cache, key) do
-      [{ _cache, ^key, touched, ttl, _value }] ->
-        case Util.has_expired?(touched, ttl) do
-          true  ->
-            Worker.del(state, key)
-            { :missing, nil }
-          false ->
-            case ttl do
-              nil -> { :ok, nil }
-              val -> { :ok, touched + val - Util.now() }
-            end
-        end
-      _unrecognised_val ->
-        { :missing, nil }
-    end
-  end
 
 end

--- a/lib/cachex/worker/transactional.ex
+++ b/lib/cachex/worker/transactional.ex
@@ -12,6 +12,9 @@ defmodule Cachex.Worker.Transactional do
   alias Cachex.Util
   alias Cachex.Worker
 
+  # define purge constants
+  @purge_override [{ :via, { :purge } }, { :hook_result, { :ok, 1 } }]
+
   @doc """
   Writes a record into the cache, and returns a result signifying whether the
   write was successful or not.
@@ -32,7 +35,7 @@ defmodule Cachex.Worker.Transactional do
       case :mnesia.read(state.cache, key) do
         [{ _cache, ^key, touched, ttl, _value } = record] ->
           case Util.has_expired?(touched, ttl) do
-            true  -> Worker.del(state, key, via: :purge) && nil
+            true  -> Worker.del(state, key, @purge_override) && nil
             false -> record
           end
         _unrecognised_val ->

--- a/lib/cachex/worker/transactional.ex
+++ b/lib/cachex/worker/transactional.ex
@@ -13,82 +13,56 @@ defmodule Cachex.Worker.Transactional do
   alias Cachex.Worker
 
   @doc """
+  Writes a record into the cache, and returns a result signifying whether the
+  write was successful or not.
+  """
+  def write(_state, record) do
+    Util.handle_transaction(fn ->
+      :mnesia.write(record) == :ok
+    end)
+  end
+
+  @doc """
   Read back the key from Mnesia, wrapping inside a read locked transaction. If
-  the key does not exist we check to see if there's a fallback function. If there
-  is we call it and then set the value into the cache, before returning it to the
-  user. Otherwise we simply return a nil value in an ok tuple.
+  the key does not exist we return a `nil` value. If the key has expired, we delete
+  it from the cache using the `:purge` action as a notification.
   """
-  def get(state, key, options) do
-    fb_fun =
-      options
-      |> Util.get_opt_function(:fallback)
-
+  def read(state, key) do
     Util.handle_transaction(fn ->
-      val = case :mnesia.read(state.cache, key) do
-        [{ _cache, ^key, touched, ttl, value }] ->
+      case :mnesia.read(state.cache, key) do
+        [{ _cache, ^key, touched, ttl, _value } = record] ->
           case Util.has_expired?(touched, ttl) do
-            true  ->
-              Worker.del(state, key)
-              :missing
-            false -> value
+            true  -> Worker.del(state, key, via: :purge) && nil
+            false -> record
           end
-        _unrecognised_val -> :missing
+        _unrecognised_val ->
+          nil
       end
-
-      case val do
-        :missing ->
-          case Util.get_fallback(state, key, fb_fun) do
-            { :ok, new_value } ->
-              { :missing, new_value }
-            { :loaded, new_value } = result ->
-              Worker.set(state, key, new_value)
-              result
-          end
-        val ->
-          { :ok, val }
-      end
-    end)
+    end, 1)
   end
 
   @doc """
-  Inserts a value directly into Mnesia not caring if we overwrite a value or not.
-  We use the parent implementation of creating a record for consistency, which
-  provides us our TTL implementation. We transform the result of the insert into
-  an ok/error tuple.
+  Updates a number of fields in a record inside the cache, by key. We do this all
+  in one sweep using a reduction on the found record. Note that the position has
+  to be offset -1 to line up with the ETS insertion (which is index 1 based).
   """
-  def set(state, key, value, options) do
-    ttl =
-      options
-      |> Util.get_opt_number(:ttl)
-
-    Util.handle_transaction(fn ->
-      state
-      |> Util.create_record(key, value, ttl)
-      |> :mnesia.write
+  def update(state, key, changes) do
+    Worker.get_and_update_raw(state, key, fn(record) ->
+      changes |> List.wrap |> Enum.reduce(record, fn({ position, value }, record) ->
+        put_elem(record, position - 1, value)
+      end)
     end)
-    |> (&(Util.create_truthy_result(&1 == { :ok, :ok }))).()
-  end
-
-  @doc """
-  Updates a key in the cache to have a new value. This does not change the touch
-  time or the TTL on the key. We return an ok/error tuple representing the state
-  of the update request.
-  """
-  def update(state, key, value, _options) do
-    state
-    |> Worker.get_and_update(key, fn(_val) -> value end, notify: false)
-    |> (&(Util.create_truthy_result(elem(&1, 0) == :ok))).()
+    { :ok, true }
   end
 
   @doc """
   Removes a record from the cache using the provided key. We wrap this in a
   write lock in order to ensure no clashing writes occur at the same time.
   """
-  def del(state, key, _options) do
+  def delete(state, key) do
     Util.handle_transaction(fn ->
-      :mnesia.delete(state.cache, key, :write)
+      :mnesia.delete(state.cache, key, :write) == :ok
     end)
-    |> (&(Util.create_truthy_result(&1 == { :ok, :ok }))).()
   end
 
   @doc """
@@ -104,18 +78,6 @@ defmodule Cachex.Worker.Transactional do
     state.cache
     |> :mnesia.clear_table
     |> Util.handle_transaction(eviction_count)
-  end
-
-  @doc """
-  Sets the expiration time on a given key based on the value passed in. We first
-  check locally to see if the key actually exists, returning an error if it doesn't.
-  This allows us to then reuse the update semantics to modify the expiration.
-  """
-  def expire(state, key, expiration, _options) do
-    Worker.get_and_update_raw(state, key, fn({ cache, ^key, _, _, value }) ->
-      { cache, key, Util.now(), expiration, value }
-    end)
-    Util.ok(true)
   end
 
   @doc """
@@ -150,68 +112,24 @@ defmodule Cachex.Worker.Transactional do
   end
 
   @doc """
-  Refreshes the internal timestamp on the record to ensure that the TTL only takes
-  place from this point forward. If the key does not exist, we return an error tuple.
-  """
-  def refresh(state, key, _options) do
-    Worker.get_and_update_raw(state, key, fn({ cache, ^key, _, ttl, value }) ->
-      { cache, key, Util.now(), ttl, value }
-    end)
-    Util.ok(true)
-  end
-
-  @doc """
   This is like `del/2` but it returns the last known value of the key as it
   existed in the cache upon deletion. We have to do a read/write combination
   when distributed, because there's no "take" equivalent in Mnesia, only ETS.
   """
   def take(state, key, _options) do
     Util.handle_transaction(fn ->
-      value = case :mnesia.read(state.cache, key) do
-        [{ _cache, ^key, touched, ttl, value }] ->
-          case Util.has_expired?(touched, ttl) do
-            true  ->
-              Worker.del(state, key)
-              { :missing, nil }
-            false ->
-              { :ok, value }
-          end
+      value = case read(state, key) do
+        { _cache, ^key, _touched, _ttl, value } ->
+          { :ok, value }
         _unrecognised_val ->
           { :missing, nil }
       end
 
-      if value != nil do
+      if elem(value, 1) != nil do
         Worker.del(state, key, notify: false)
       end
 
       value
-    end)
-  end
-
-  @doc """
-  Checks the remaining TTL on a provided key. We do this by retrieving the local
-  record and pulling out the touched and ttl fields. In order to calculate the
-  remaining time, we simply subtract the sum of these numbers from the current
-  time in milliseconds. We return the remaining time to live in an ok tuple. If
-  the key does not exist in the cache, we return an error tuple with a warning.
-  """
-  def ttl(state, key, _options) do
-    Util.handle_transaction(fn ->
-      case :mnesia.read(state.cache, key) do
-        [{ _cache, ^key, touched, ttl, _value }] ->
-          case Util.has_expired?(touched, ttl) do
-            true  ->
-              Worker.del(state, key)
-              { :missing, nil }
-            false ->
-              case ttl do
-                nil -> { :ok, nil }
-                val -> { :ok, touched + val - Util.now() }
-              end
-          end
-        _unrecognised_val ->
-          { :missing, nil }
-      end
     end)
   end
 

--- a/test/cachex_test/stats/registry/local.exs
+++ b/test/cachex_test/stats/registry/local.exs
@@ -130,13 +130,21 @@ defmodule CachexTest.Stats.Registry.Local do
     get_result = Cachex.get(state.cache, "missing_key", fallback: &(&1))
     assert(get_result == { :loaded, "missing_key" })
 
+    set_result = Cachex.set(state.cache, "key", "value", ttl: 1)
+    assert(set_result == { :ok, true })
+
+    :timer.sleep(2)
+
+    get_result = Cachex.get(state.cache, "key")
+    assert(get_result == { :missing, nil })
+
     { status, stats } = Cachex.stats(state.cache, for: :raw)
 
     assert(status == :ok)
-    assert(stats[:get] == %{ ok: 1, missing: 1, loaded: 1 })
+    assert(stats[:get] == %{ ok: 1, missing: 2, loaded: 1 })
     # setCount is 2 fallbacks also do a set into the cache
     # missCount is 2 because loading a key also is a miss
-    assert(stats[:global] == %{ opCount: 5, setCount: 2, hitCount: 1, missCount: 2, loadCount: 1 })
+    assert(stats[:global] == %{ opCount: 8, expiredCount: 1, setCount: 3, hitCount: 1, missCount: 3, loadCount: 1 })
   end
 
   test "stats with a get_and_update action", state do

--- a/test/cachex_test/stats/registry/transactional.exs
+++ b/test/cachex_test/stats/registry/transactional.exs
@@ -130,13 +130,21 @@ defmodule CachexTest.Stats.Registry.Transactional do
     get_result = Cachex.get(state.cache, "missing_key", fallback: &(&1))
     assert(get_result == { :loaded, "missing_key" })
 
+    set_result = Cachex.set(state.cache, "key", "value", ttl: 1)
+    assert(set_result == { :ok, true })
+
+    :timer.sleep(2)
+
+    get_result = Cachex.get(state.cache, "key")
+    assert(get_result == { :missing, nil })
+
     { status, stats } = Cachex.stats(state.cache, for: :raw)
 
     assert(status == :ok)
-    assert(stats[:get] == %{ ok: 1, missing: 1, loaded: 1 })
+    assert(stats[:get] == %{ ok: 1, missing: 2, loaded: 1 })
     # setCount is 2 fallbacks also do a set into the cache
     # missCount is 2 because loading a key also is a miss
-    assert(stats[:global] == %{ opCount: 5, setCount: 2, hitCount: 1, missCount: 2, loadCount: 1 })
+    assert(stats[:global] == %{ opCount: 8, expiredCount: 1, setCount: 3, hitCount: 1, missCount: 3, loadCount: 1 })
   end
 
   test "stats with a get_and_update action", state do

--- a/test/cachex_test/util.exs
+++ b/test/cachex_test/util.exs
@@ -186,6 +186,7 @@ defmodule CachexTest.Util do
     assert(Util.handle_transaction({ :atomic, { :error, :test } }) == { :error, :test })
     assert(Util.handle_transaction({ :atomic, { :ok, :test } }) == { :ok, :test })
     assert(Util.handle_transaction({ :atomic, { :loaded, :test } }) == { :loaded, :test })
+    assert(Util.handle_transaction({ :atomic, { :missing, :test } }) == { :missing, :test })
     assert(Util.handle_transaction({ :atomic, :test }) == { :ok, :test })
     assert(Util.handle_transaction({ :aborted, :test }) == { :error, :test })
   end


### PR DESCRIPTION
This should be enough to cover what's needed for #6.

I defined a CRUD behaviour on all workers, and then pulled everything out which could be. The advantage is that TTL is checked in a single place only (bar `take/3` in `local.ex`). It also cuts down on a fair amount of duplication.

I also snuck in a `:hook_result` option to all Worker functions which will override any results sent to the hook. I can't imagine this will be used often, but it was needed to fix #10.

This PR will also catch #10 and make it far easier to implement #11.