### PR TITLE
Provide the ability to disable on-demand expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Caches can accept a list of options during initialization, which determine vario
 |     ets_opts     |   list of options  |               A list of options to give to the ETS table.               |
 | default_fallback |       function     |   A function accepting a key which is used for multi-layered caching.   |
 |    default_ttl   |     milliseconds   | A default expiration time for a key when being placed inside the cache. |
+|    disable_ode   |  `true` or `false` | Whether or not to disable on-demand expirations when reading back keys. |
 |   fallback_args  |  list of arguments |  A list of arguments to pass alongside the key to a fallback function.  |
 |       hooks      |    list of Hooks   |    A list of execution hooks (see below) to listen on cache actions.    |
 |       nodes      |    list of nodes   |       A list of remote nodes to connect to and replicate against.       |
@@ -265,7 +266,7 @@ This means that at any point, if you have the TTL worker disabled, you can reali
 Of course, if you have the TTL worker disabled you need to be careful of a growing cache size due to keys being added and then never being accessed again. This is fine if you have a very restrictive keyset, but for
 arbitrary keys this is probably not what you want.
 
-This type of expiration is always enabled and cannot be disabled. Due to the extremely minimal overhead, it doesn't really make sense to make this optional.
+Although the overhead of on-demand expiration is minimal, as of v0.10.0 it can be disabled using the `disable_ode` option inside `start/1` or `start_link/2`. This is useful if you have a Janitor running and don't mind keys existing a little beyond their expiration (for example if  TTL is being used purely as a means to control memory usage). The main advantage of disabling ODE is that the execution time of any given read operation is more predictable due to avoiding the case where some reads also evict the key.
 
 #### Janitors
 

--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -62,7 +62,7 @@ defmodule Cachex do
 
       The name of the cache you're creating, typically an atom.
 
-          Cachex.start_link([ name: :my_cache ])
+          iex> Cachex.start_link([ name: :my_cache ])
 
   ### Optional
 
@@ -70,7 +70,7 @@ defmodule Cachex do
 
       A list of options to pass to the ETS table initialization.
 
-          Cachex.start_link([ name: :my_cache, ets_opts: [ { :write_concurrency, false } ] ])
+          iex> Cachex.start_link([ name: :my_cache, ets_opts: [ { :write_concurrency, false } ] ])
 
     - **default_fallback**
 
@@ -78,16 +78,24 @@ defmodule Cachex do
       This function is called with a key which has no value, in order to allow loading
       from a different location.
 
-          Cachex.start_link([ name: :my_cache, default_fallback: fn(key) ->
-            generate_value(key)
-          end])
+          iex> Cachex.start_link([ name: :my_cache, default_fallback: fn(key) ->
+          ...>   generate_value(key)
+          ...> end])
 
     - **default_ttl**
 
       A default expiration time to place on any keys inside the cache (this can be
       overridden when a key is set). This value is in **milliseconds**.
 
-          Cachex.start_link([ name: :my_cache, default_ttl: :timer.seconds(1) ])
+          iex> Cachex.start_link([ name: :my_cache, default_ttl: :timer.seconds(1) ])
+
+    - **disable_ode**
+
+      If true, on-demand expiration will be disabled. Keys will only be removed
+      by Janitor processes, or by calling `purge/2` directly. Useful in case you
+      have a Janitor running and don't want potential deletes to impact your reads.
+
+          iex> Cachex.start_link([ name: :my_cache, disable_ode: true ])
 
     - **fallback_args**
 
@@ -96,10 +104,10 @@ defmodule Cachex do
       your args appropriately. This can be used to pass through things such as clients and
       connections.
 
-          Cachex.start_link([ name: :my_cache, fallback_args: [redis_client] ])
-          Cachex.get(:my_cache, "key", fallback: fn(key, redis_client) ->
-            redis_client.get(key)
-          end)
+          iex> Cachex.start_link([ name: :my_cache, fallback_args: [redis_client] ])
+          iex> Cachex.get(:my_cache, "key", fallback: fn(key, redis_client) ->
+          ...>   redis_client.get(key)
+          ...> end)
 
     - **hooks**
 
@@ -107,15 +115,15 @@ defmodule Cachex do
       taken place. These hooks should be instances of Cachex.Hook and implement the hook
       behaviour. An example hook can be found in `Cachex.Stats`.
 
-        hook = %Cachex.Hook{ module: MyHook, type: :post }
-        Cachex.start_link([ name: :my_cache, hooks: [hook] ])
+          iex> hook = %Cachex.Hook{ module: MyHook, type: :post }
+          iex> Cachex.start_link([ name: :my_cache, hooks: [hook] ])
 
     - **nodes**
 
       A list of nodes that the store should replicate to. Using this does not automatically
       enable transactions; they need to be enabled separately.
 
-          Cachex.start_link([ name: :my_cache, nodes: [node()] ])
+          iex> Cachex.start_link([ name: :my_cache, nodes: [node()] ])
 
     - **record_stats**
 
@@ -123,7 +131,7 @@ defmodule Cachex do
       overhead due to being implemented as an asynchronous hook (roughly 1µ/op). Stats
       can be retrieve from a running cache by using `stats/1`.
 
-          Cachex.start_link([ name: :my_cache, record_stats: true ])
+          iex> Cachex.start_link([ name: :my_cache, record_stats: true ])
 
     - **remote**
 
@@ -132,7 +140,7 @@ defmodule Cachex do
       automatically set to true if you have set `:nodes` to a list of nodes other than
       just `[node()]`.
 
-          Cachex.start_link([ name: :my_cache, remote: true ])
+          iex> Cachex.start_link([ name: :my_cache, remote: true ])
 
     - **transactional**
 
@@ -142,7 +150,7 @@ defmodule Cachex do
       and you have a lot of writes going to the same keys. Note that this is at least 10x
       slower than when set to false.
 
-          Cachex.start_link([ name: :my_cache, transactional: true ])
+          iex> Cachex.start_link([ name: :my_cache, transactional: true ])
 
     - **ttl_interval**
 
@@ -153,7 +161,7 @@ defmodule Cachex do
       application, but it may make sense to lower the frequency if you don't have many keys
       expiring at one time. This value is set in **milliseconds**.
 
-          Cachex.start_link([ name: :my_cache, ttl_interval: :timer.seconds(5) ])
+          iex> Cachex.start_link([ name: :my_cache, ttl_interval: :timer.seconds(5) ])
 
   """
   @spec start_link(options, options) :: { atom, pid }

--- a/lib/cachex/options.ex
+++ b/lib/cachex/options.ex
@@ -67,7 +67,7 @@ defmodule Cachex.Options do
       mod -> Hook.initialize_hooks(mod)
     end
 
-    stats_hook = case !!options[:record_stats] do
+    stats_hook = case Util.truthy?(options[:record_stats]) do
       true ->
         Hook.initialize_hooks(%Hook{
           args: [ ],
@@ -87,13 +87,12 @@ defmodule Cachex.Options do
 
     is_remote = cond do
       remote_node_list != nil && remote_node_list != [node()] -> true
-      !!options[:remote] -> true
-      true -> false
+      true -> Util.truthy?(options[:remote])
     end
 
     %__MODULE__{
       "cache": cache,
-      "disable_ode": !!options[:disable_ode],
+      "disable_ode": Util.truthy?(options[:disable_ode]),
       "ets_opts": ets_opts,
       "default_fallback": default_fallback,
       "default_ttl": default_ttl,
@@ -103,7 +102,7 @@ defmodule Cachex.Options do
       "pre_hooks": pre_hooks,
       "post_hooks": post_hooks,
       "remote": is_remote,
-      "transactional": !!options[:transactional],
+      "transactional": Util.truthy?(options[:transactional]),
       "ttl_interval": ttl_interval
     }
   end

--- a/lib/cachex/options.ex
+++ b/lib/cachex/options.ex
@@ -8,6 +8,7 @@ defmodule Cachex.Options do
   alias Cachex.Util
 
   defstruct cache: nil,             # the name of the cache
+            disable_ode: false,     # whether we disable on-demand expiration
             ets_opts: nil,          # any options to give to ETS
             default_fallback: nil,  # the default fallback implementation
             default_ttl: nil,       # any default ttl values to use
@@ -92,6 +93,7 @@ defmodule Cachex.Options do
 
     %__MODULE__{
       "cache": cache,
+      "disable_ode": !!options[:disable_ode],
       "ets_opts": ets_opts,
       "default_fallback": default_fallback,
       "default_ttl": default_ttl,

--- a/lib/cachex/util.ex
+++ b/lib/cachex/util.ex
@@ -184,6 +184,10 @@ defmodule Cachex.Util do
   Small utility to figure out if a document has expired based on the last touched
   time and the TTL of the document.
   """
+  def has_expired?(state, touched, ttl) when is_number(touched) and is_number(ttl) do
+    if state.options.disable_ode, do: false, else: touched + ttl < now
+  end
+  def has_expired?(_state, _touched, _ttl), do: false
   def has_expired?(touched, ttl) when is_number(touched) and is_number(ttl) do
     touched + ttl < now
   end

--- a/lib/cachex/util.ex
+++ b/lib/cachex/util.ex
@@ -309,4 +309,10 @@ defmodule Cachex.Util do
   def successfully_started?({ :aborted, { :already_exists, _table } }), do: true
   def successfully_started?(_), do: false
 
+  @doc """
+  Determines if a value is truthy or not. This just adds a little bit of extra
+  readability where needed.
+  """
+  def truthy?(value), do: !!value
+
 end

--- a/lib/cachex/worker/local.ex
+++ b/lib/cachex/worker/local.ex
@@ -35,11 +35,9 @@ defmodule Cachex.Worker.Local do
   def read(state, key) do
     case :ets.lookup(state.cache, key) do
       [{ _cache, ^key, touched, ttl, _value } = record] ->
-        cond do
-          state.options.disable_ode or not Util.has_expired?(touched, ttl) ->
-            record
-          true ->
-            Worker.del(state, key, @purge_override) && nil
+        case Util.has_expired?(state, touched, ttl) do
+          true  -> Worker.del(state, key, @purge_override) && nil
+          false -> record
         end
       _unrecognised_val ->
         nil

--- a/lib/cachex/worker/local.ex
+++ b/lib/cachex/worker/local.ex
@@ -35,9 +35,11 @@ defmodule Cachex.Worker.Local do
   def read(state, key) do
     case :ets.lookup(state.cache, key) do
       [{ _cache, ^key, touched, ttl, _value } = record] ->
-        case Util.has_expired?(touched, ttl) do
-          true  -> Worker.del(state, key, @purge_override) && nil
-          false -> record
+        cond do
+          state.options.disable_ode or not Util.has_expired?(touched, ttl) ->
+            record
+          true ->
+            Worker.del(state, key, @purge_override) && nil
         end
       _unrecognised_val ->
         nil

--- a/lib/cachex/worker/remote.ex
+++ b/lib/cachex/worker/remote.ex
@@ -35,11 +35,9 @@ defmodule Cachex.Worker.Remote do
   def read(state, key) do
     case :mnesia.dirty_read(state.cache, key) do
       [{ _cache, ^key, touched, ttl, _value } = record] ->
-        cond do
-          state.options.disable_ode or not Util.has_expired?(touched, ttl) ->
-            record
-          true ->
-            Worker.del(state, key, @purge_override) && nil
+        case Util.has_expired?(state, touched, ttl) do
+          true  -> Worker.del(state, key, @purge_override) && nil
+          false -> record
         end
       _unrecognised_val ->
         nil

--- a/lib/cachex/worker/transactional.ex
+++ b/lib/cachex/worker/transactional.ex
@@ -34,11 +34,9 @@ defmodule Cachex.Worker.Transactional do
     Util.handle_transaction(fn ->
       case :mnesia.read(state.cache, key) do
         [{ _cache, ^key, touched, ttl, _value } = record] ->
-          cond do
-            state.options.disable_ode or not Util.has_expired?(touched, ttl) ->
-              record
-            true ->
-              Worker.del(state, key, @purge_override) && nil
+          case Util.has_expired?(state, touched, ttl) do
+            true  -> Worker.del(state, key, @purge_override) && nil
+            false -> record
           end
         _unrecognised_val ->
           nil

--- a/test/cachex_test/exists.exs
+++ b/test/cachex_test/exists.exs
@@ -29,10 +29,22 @@ defmodule CachexTest.Exists do
     set_result = Cachex.set(state.cache, "my_key", 5, ttl: 5)
     assert(set_result == { :ok, true })
 
-    :timer.sleep(10)
+    :timer.sleep(6)
 
     exists_result = Cachex.exists?(state.cache, "my_key")
     assert(exists_result == { :ok, false })
+  end
+
+  test "exists? with an expired key and disable_ode", _state do
+    cache = TestHelper.create_cache([ disable_ode: true ])
+
+    set_result = Cachex.set(cache, "my_key", 5, ttl: 5)
+    assert(set_result == { :ok, true })
+
+    :timer.sleep(6)
+
+    exists_result = Cachex.exists?(cache, "my_key")
+    assert(exists_result == { :ok, true })
   end
 
   test "exists? with a missing key", state do

--- a/test/cachex_test/get/local.exs
+++ b/test/cachex_test/get/local.exs
@@ -89,10 +89,22 @@ defmodule CachexTest.Get.Local do
     set_result = Cachex.set(state.cache, "my_key", "my_value", ttl: 5)
     assert(set_result == { :ok, true })
 
-    :timer.sleep(10)
+    :timer.sleep(6)
 
     get_result = Cachex.get(state.cache, "my_key")
     assert(get_result == { :missing, nil })
+  end
+
+  test "key get with expired key and disable_ode", _state do
+    cache = TestHelper.create_cache([ disable_ode: true ])
+
+    set_result = Cachex.set(cache, "my_key", "my_value", ttl: 5)
+    assert(set_result == { :ok, true })
+
+    :timer.sleep(6)
+
+    get_result = Cachex.get(cache, "my_key")
+    assert(get_result == { :ok, "my_value" })
   end
 
 end

--- a/test/cachex_test/get/remote.exs
+++ b/test/cachex_test/get/remote.exs
@@ -89,10 +89,22 @@ defmodule CachexTest.Get.Remote do
     set_result = Cachex.set(state.cache, "my_key", "my_value", ttl: 5)
     assert(set_result == { :ok, true })
 
-    :timer.sleep(10)
+    :timer.sleep(6)
 
     get_result = Cachex.get(state.cache, "my_key")
     assert(get_result == { :missing, nil })
+  end
+
+  test "key get with expired key and disable_ode", _state do
+    cache = TestHelper.create_cache([ disable_ode: true, remote: true ])
+
+    set_result = Cachex.set(cache, "my_key", "my_value", ttl: 5)
+    assert(set_result == { :ok, true })
+
+    :timer.sleep(6)
+
+    get_result = Cachex.get(cache, "my_key")
+    assert(get_result == { :ok, "my_value" })
   end
 
 end

--- a/test/cachex_test/get/transactional.exs
+++ b/test/cachex_test/get/transactional.exs
@@ -89,10 +89,22 @@ defmodule CachexTest.Get.Transactional do
     set_result = Cachex.set(state.cache, "my_key", "my_value", ttl: 5)
     assert(set_result == { :ok, true })
 
-    :timer.sleep(10)
+    :timer.sleep(6)
 
     get_result = Cachex.get(state.cache, "my_key")
     assert(get_result == { :missing, nil })
+  end
+
+  test "key get with expired key and disable_ode", _state do
+    cache = TestHelper.create_cache([ disable_ode: true, transactional: true ])
+
+    set_result = Cachex.set(cache, "my_key", "my_value", ttl: 5)
+    assert(set_result == { :ok, true })
+
+    :timer.sleep(6)
+
+    get_result = Cachex.get(cache, "my_key")
+    assert(get_result == { :ok, "my_value" })
   end
 
 end

--- a/test/cachex_test/ttl/local.exs
+++ b/test/cachex_test/ttl/local.exs
@@ -37,10 +37,23 @@ defmodule CachexTest.Ttl.Local do
     set_result = Cachex.set(state.cache, "my_key", "my_value", ttl: 5)
     assert(set_result == { :ok, true })
 
-    :timer.sleep(10)
+    :timer.sleep(6)
 
     ttl_result = Cachex.ttl(state.cache, "my_key")
     assert(ttl_result == { :missing, nil })
+  end
+
+  test "ttl with expired key and disable_ode does not remove the key", _state do
+    cache = TestHelper.create_cache([ disable_ode: true ])
+
+    set_result = Cachex.set(cache, "my_key", "my_value", ttl: 5)
+    assert(set_result == { :ok, true })
+
+    :timer.sleep(6)
+
+    { ttl_status, ttl_result } = Cachex.ttl(cache, "my_key")
+    assert(ttl_status == :ok)
+    assert(ttl_result < 0)
   end
 
 end

--- a/test/cachex_test/ttl/remote.exs
+++ b/test/cachex_test/ttl/remote.exs
@@ -37,10 +37,23 @@ defmodule CachexTest.Ttl.Remote do
     set_result = Cachex.set(state.cache, "my_key", "my_value", ttl: 5)
     assert(set_result == { :ok, true })
 
-    :timer.sleep(10)
+    :timer.sleep(6)
 
     ttl_result = Cachex.ttl(state.cache, "my_key")
     assert(ttl_result == { :missing, nil })
+  end
+
+  test "ttl with expired key and disable_ode does not remove the key", _state do
+    cache = TestHelper.create_cache([ disable_ode: true, remote: true ])
+
+    set_result = Cachex.set(cache, "my_key", "my_value", ttl: 5)
+    assert(set_result == { :ok, true })
+
+    :timer.sleep(6)
+
+    { ttl_status, ttl_result } = Cachex.ttl(cache, "my_key")
+    assert(ttl_status == :ok)
+    assert(ttl_result < 0)
   end
 
 end

--- a/test/cachex_test/ttl/transactional.exs
+++ b/test/cachex_test/ttl/transactional.exs
@@ -37,10 +37,23 @@ defmodule CachexTest.Ttl.Transactional do
     set_result = Cachex.set(state.cache, "my_key", "my_value", ttl: 5)
     assert(set_result == { :ok, true })
 
-    :timer.sleep(10)
+    :timer.sleep(6)
 
     ttl_result = Cachex.ttl(state.cache, "my_key")
     assert(ttl_result == { :missing, nil })
+  end
+
+  test "ttl with expired key and disable_ode does not remove the key", _state do
+    cache = TestHelper.create_cache([ disable_ode: true, transactional: true ])
+
+    set_result = Cachex.set(cache, "my_key", "my_value", ttl: 5)
+    assert(set_result == { :ok, true })
+
+    :timer.sleep(6)
+
+    { ttl_status, ttl_result } = Cachex.ttl(cache, "my_key")
+    assert(ttl_status == :ok)
+    assert(ttl_result < 0)
   end
 
 end

--- a/test/cachex_test/util.exs
+++ b/test/cachex_test/util.exs
@@ -204,6 +204,24 @@ defmodule CachexTest.Util do
     refute(Util.has_expired?(nil, nil))
   end
 
+  test "util.has_expired?/3 with disable_ode determines if a date and ttl has passed" do
+    state = %Cachex.Worker{ options: %Cachex.Options { disable_ode: true } }
+    refute(Util.has_expired?(state, Util.now(), -5000))
+    refute(Util.has_expired?(state, Util.now(), 5000))
+    refute(Util.has_expired?(state, nil, 5000))
+    refute(Util.has_expired?(state, 5000, nil))
+    refute(Util.has_expired?(state, nil, nil))
+  end
+
+  test "util.has_expired?/3 without disable_ode determines if a date and ttl has passed" do
+    state = %Cachex.Worker{ options: %Cachex.Options { disable_ode: false } }
+    assert(Util.has_expired?(state, Util.now(), -5000))
+    refute(Util.has_expired?(state, Util.now(), 5000))
+    refute(Util.has_expired?(state, nil, 5000))
+    refute(Util.has_expired?(state, 5000, nil))
+    refute(Util.has_expired?(state, nil, nil))
+  end
+
   test "util.has_arity?/2 determines if a function has a given arity" do
     assert(Util.has_arity?(&(&1), 1))
     refute(Util.has_arity?(&(&1), 2))


### PR DESCRIPTION
This PR will add the feature to disable on-demand expirations per #11. This is useful when you don't really care about guaranteed TTL accuracy (for example if you're using TTLs to just lower your memory usage). In this case the deletes on demand can lower your read throughput, so this allows you to trade accuracy for read performance.