### PR TITLE
Add handling covering incr/3 on non-numeric keys

### DIFF
--- a/lib/cachex/worker/local.ex
+++ b/lib/cachex/worker/local.ex
@@ -116,15 +116,19 @@ defmodule Cachex.Worker.Local do
       state
       |> Worker.exists?(key, notify: false)
 
-    new_value =
-      state.cache
-      |> :ets.update_counter(key, { 5, amount }, new_record)
+    try do
+      new_value =
+        state.cache
+        |> :ets.update_counter(key, { 5, amount }, new_record)
 
-    case exists_key do
-      { :ok, true } ->
-        { :ok, new_value }
-      { :ok, false } ->
-        { :missing, new_value }
+      case exists_key do
+        { :ok, true } ->
+          { :ok, new_value }
+        { :ok, false } ->
+          { :missing, new_value }
+      end
+    rescue
+      _e -> { :error, :non_numeric_value }
     end
   end
 

--- a/lib/cachex/worker/transactional.ex
+++ b/lib/cachex/worker/transactional.ex
@@ -109,8 +109,12 @@ defmodule Cachex.Worker.Transactional do
       |> Util.get_opt_number(:initial, 0)
 
     Worker.get_and_update(state, key, fn
-      (nil) -> initial + amount
-      (val) -> val + amount
+      (val) when is_number(val) ->
+        val + amount
+      (nil) ->
+        initial + amount
+      (_na) ->
+        Cachex.abort(state, :non_numeric_value)
     end, notify: false)
   end
 

--- a/test/cachex_test/decr/local.exs
+++ b/test/cachex_test/decr/local.exs
@@ -37,6 +37,17 @@ defmodule CachexTest.Decr.Local do
     assert(decr_result == { :missing, 4 })
   end
 
+  test "decr with non-numeric value", state do
+    set_result = Cachex.set(state.cache, "my_key", "my_value")
+    assert(set_result == { :ok, true })
+
+    get_result = Cachex.get(state.cache, "my_key")
+    assert(get_result == { :ok, "my_value" })
+
+    decr_result = Cachex.decr(state.cache, "my_key")
+    assert(decr_result == { :error, "Unable to operate on non-numeric value" })
+  end
+
   test "decr with async is faster than non-async", state do
     { async_time, _res } = :timer.tc(fn ->
       Cachex.decr(state.cache, "my_key1", async: true)

--- a/test/cachex_test/decr/remote.exs
+++ b/test/cachex_test/decr/remote.exs
@@ -37,6 +37,17 @@ defmodule CachexTest.Decr.Remote do
     assert(decr_result == { :missing, 4 })
   end
 
+  test "decr with non-numeric value", state do
+    set_result = Cachex.set(state.cache, "my_key", "my_value")
+    assert(set_result == { :ok, true })
+
+    get_result = Cachex.get(state.cache, "my_key")
+    assert(get_result == { :ok, "my_value" })
+
+    decr_result = Cachex.decr(state.cache, "my_key")
+    assert(decr_result == { :error, "Unable to operate on non-numeric value" })
+  end
+
   test "decr with async is faster than non-async", state do
     { async_time, _res } = :timer.tc(fn ->
       Cachex.decr(state.cache, "my_key1", async: true)

--- a/test/cachex_test/decr/transactional.exs
+++ b/test/cachex_test/decr/transactional.exs
@@ -37,6 +37,17 @@ defmodule CachexTest.Decr.Transactional do
     assert(decr_result == { :missing, 4 })
   end
 
+  test "decr with non-numeric value", state do
+    set_result = Cachex.set(state.cache, "my_key", "my_value")
+    assert(set_result == { :ok, true })
+
+    get_result = Cachex.get(state.cache, "my_key")
+    assert(get_result == { :ok, "my_value" })
+
+    decr_result = Cachex.decr(state.cache, "my_key")
+    assert(decr_result == { :error, "Unable to operate on non-numeric value" })
+  end
+
   test "decr with async is faster than non-async", state do
     { async_time, _res } = :timer.tc(fn ->
       Cachex.decr(state.cache, "my_key1", async: true)

--- a/test/cachex_test/get_and_update.exs
+++ b/test/cachex_test/get_and_update.exs
@@ -145,4 +145,11 @@ defmodule CachexTest.GetAndUpdate do
     assert(get_result == { :missing, nil })
   end
 
+  test "get and update with abort and unrecognised message", state do
+    gau_result = Cachex.get_and_update(state.cache, "my_key", fn(_value) ->
+      Cachex.abort(state.cache, :unrecognised_error)
+    end)
+    assert(gau_result == { :error, :unrecognised_error })
+  end
+
 end

--- a/test/cachex_test/incr/local.exs
+++ b/test/cachex_test/incr/local.exs
@@ -37,6 +37,17 @@ defmodule CachexTest.Incr.Local do
     assert(incr_result == { :missing, 6 })
   end
 
+  test "incr with non-numeric value", state do
+    set_result = Cachex.set(state.cache, "my_key", "my_value")
+    assert(set_result == { :ok, true })
+
+    get_result = Cachex.get(state.cache, "my_key")
+    assert(get_result == { :ok, "my_value" })
+
+    incr_result = Cachex.incr(state.cache, "my_key")
+    assert(incr_result == { :error, "Unable to operate on non-numeric value" })
+  end
+
   test "incr with async is faster than non-async", state do
     { async_time, _res } = :timer.tc(fn ->
       Cachex.incr(state.cache, "my_key1", async: true)

--- a/test/cachex_test/incr/remote.exs
+++ b/test/cachex_test/incr/remote.exs
@@ -37,6 +37,17 @@ defmodule CachexTest.Incr.Remote do
     assert(incr_result == { :missing, 6 })
   end
 
+  test "incr with non-numeric value", state do
+    set_result = Cachex.set(state.cache, "my_key", "my_value")
+    assert(set_result == { :ok, true })
+
+    get_result = Cachex.get(state.cache, "my_key")
+    assert(get_result == { :ok, "my_value" })
+
+    incr_result = Cachex.incr(state.cache, "my_key")
+    assert(incr_result == { :error, "Unable to operate on non-numeric value" })
+  end
+
   test "incr with async is faster than non-async", state do
     { async_time, _res } = :timer.tc(fn ->
       Cachex.incr(state.cache, "my_key1", async: true)

--- a/test/cachex_test/incr/transactional.exs
+++ b/test/cachex_test/incr/transactional.exs
@@ -37,6 +37,17 @@ defmodule CachexTest.Incr.Transactional do
     assert(incr_result == { :missing, 6 })
   end
 
+  test "incr with non-numeric value", state do
+    set_result = Cachex.set(state.cache, "my_key", "my_value")
+    assert(set_result == { :ok, true })
+
+    get_result = Cachex.get(state.cache, "my_key")
+    assert(get_result == { :ok, "my_value" })
+
+    incr_result = Cachex.incr(state.cache, "my_key")
+    assert(incr_result == { :error, "Unable to operate on non-numeric value" })
+  end
+
   test "incr with async is faster than non-async", state do
     { async_time, _res } = :timer.tc(fn ->
       Cachex.incr(state.cache, "my_key1", async: true)


### PR DESCRIPTION
Currently there's a bug in `decr/3` and `incr/3` in that if you create a non-numeric value beforehand, a call to either will crash the server.

This PR will add coverage around this issue and resolve it in all workers. I also added handling to `get_and_update/4` to better support transactions and unrecognised errors.

You can now `Cachex.abort(worker, :reason)` from inside a `get_and_update/4` call to exit early and not commit the changes, and `{ :error, :reason }` will be returned.