### PR TITLE
Fix up Janitors to ensure they broadcast to all hooks

### DIFF
--- a/lib/cachex/janitor.ex
+++ b/lib/cachex/janitor.ex
@@ -14,8 +14,7 @@ defmodule Cachex.Janitor do
   # we split into a separate GenServer for safety in case it takes a while.
 
   defstruct cache: nil,         # the name of the cache
-            interval: nil,      # the interval to check the ttl
-            stats_ref: nil      # a reference to send stats to
+            interval: nil       # the interval to check the ttl
 
   @doc """
   Simple initialization for use in the main owner process in order to start an
@@ -46,8 +45,7 @@ defmodule Cachex.Janitor do
   def init(options \\ %Cachex.Options { }) do
     state = %__MODULE__{
       cache: options.cache,
-      interval: options.ttl_interval,
-      stats_ref: Cachex.Hook.ref_by_module(options.post_hooks, Cachex.Stats)
+      interval: options.ttl_interval
     }
     { :ok, schedule_check(state) }
   end

--- a/lib/cachex/janitor.ex
+++ b/lib/cachex/janitor.ex
@@ -78,9 +78,7 @@ defmodule Cachex.Janitor do
   # Schedules a check to occur after the designated interval. Once scheduled,
   # returns the state - this is just sugar for pipelining with a state.
   defp update_evictions({ :ok, evictions } = result, state) when evictions > 0 do
-    if state.stats_ref != nil do
-      GenEvent.notify(state.stats_ref, { :async, { { :purge, [] }, result } })
-    end
+    GenServer.cast(state.cache, { :broadcast, { { :purge, [] }, result } })
     state
   end
   defp update_evictions(_other, state), do: state

--- a/lib/cachex/worker.ex
+++ b/lib/cachex/worker.ex
@@ -410,6 +410,15 @@ defmodule Cachex.Worker do
     { :reply, new_state, new_state }
   end
 
+  @doc """
+  Handler for broadcasting a set of actions and results to all registered hooks.
+  This is fired by out-of-proc calls (i.e. Janitors) which need to notify hooks.
+  """
+  def handle_cast({ :broadcast, { action, result } }, state) do
+    do_action(state, action, fn -> result end)
+    { :noreply, state }
+  end
+
   ###
   # Functions designed to only be used internally (i.e. those not forwarded to
   # the main Cachex interfaces).


### PR DESCRIPTION
This fixes #17. Basically the Janitors were only reporting to the Stats hook (for whatever reason). This simply tweaks them to broadcast to all attached hooks via the worker.

I have also included a small `:broadcast` hook into the worker module to make it easier to jump messages straight to hooks. This adds an extra message to the worker but it should be extremely fast (bar any sync hooks).