### PR TITLE
Provide a way to access workers in hooks

### DIFF
--- a/lib/cachex/worker.ex
+++ b/lib/cachex/worker.ex
@@ -60,7 +60,7 @@ defmodule Cachex.Worker do
       cache: options.cache,
       options: options
     }
-    { :ok, state }
+    { :ok, modify_hooks(state) }
   end
 
   ###
@@ -407,6 +407,8 @@ defmodule Cachex.Worker do
       %__MODULE__{ state | actions: __MODULE__.Remote, options: new_options }
     end
 
+    modify_hooks(new_state)
+
     { :reply, new_state, new_state }
   end
 
@@ -495,6 +497,17 @@ defmodule Cachex.Worker do
       other_results ->
         other_results
     end
+  end
+
+  # A binding for the update of hooks requiring anything of this cache. As it
+  # stands this is just the worker, but we call from multiple places to it makes
+  # sense to break out into a function.
+  defp modify_hooks(%__MODULE__{ options: options } = state) do
+    options.pre_hooks
+    |> Enum.concat(options.post_hooks)
+    |> Enum.filter(&(&1.provide |> List.wrap |> Enum.member?(:worker)))
+    |> Enum.each(&(Hook.provision(&1, { :worker, state })))
+    state
   end
 
 end


### PR DESCRIPTION
This will fix #1. It's just a starting point, but I think this should be sufficient going forward.

This PR adds a `:provide` option to all hooks, allowing you to ask for various things to be provided to the hook (although currently it's just `:worker`). This will then call `handle_info/2` in the hook with a `{ :provision, { :worker, worker } }` message and allow you to bind the worker to your state. 

You can then pass this worker to Cachex (i.e. `Cachex.get(worker, "key")`) for cache access within the hooks without jumping back over the proc barrier to the worker server.