### PR TITLE
Add inspection options to view the last Janitor run

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -826,6 +826,8 @@ defmodule Cachex do
       yet been removed by TTL handlers.
     * `{ :expired, :keys }` - the list of unordered keys which have expired but
       have not yet been removed by TTL handlers.
+    * `{ :janitor, :last }` - returns various information about the last run of
+      a Janitor process.
     * `{ :memory, :bytes }` - the memory footprint of the cache in bytes.
     * `{ :memory, :binary }` - the memory footprint of the cache in binary format.
     * `:worker` - the internal state of the cache worker. This blocks the cache

--- a/lib/cachex/inspector.ex
+++ b/lib/cachex/inspector.ex
@@ -33,9 +33,6 @@ defmodule Cachex.Inspector do
   Returns information about the expired keys currently inside the cache (i.e. keys
   which  will be purged in the next Janitor run).
   """
-  def inspect(cache, :expired) do
-    __MODULE__.inspect(cache, { :expired, :count })
-  end
   def inspect(cache, { :expired, :count }) do
     query =
       true
@@ -59,12 +56,26 @@ defmodule Cachex.Inspector do
   end
 
   @doc """
+  Returns information about the last run of the Janitor process (if there is one).
+  """
+  def inspect(cache, { :janitor, :last }) do
+    ref =
+      cache
+      |> Util.janitor_for_cache
+
+    if :erlang.whereis(ref) != :undefined do
+      ref
+      |> GenServer.call(:last)
+      |> Util.ok
+    else
+      { :error, "Janitor not running for cache #{inspect(cache)}" }
+    end
+  end
+
+  @doc """
   Requests the memory information from a cache, and converts it using the word
   size of the system, in order to return a number of bytes or as a binary.
   """
-  def inspect(cache, :memory) do
-    __MODULE__.inspect(cache, { :memory, :bytes })
-  end
   def inspect(cache, { :memory, type }) do
     mem_words = :erlang.system_info(:wordsize)
     mem_cache = :mnesia.table_info(cache, :memory)

--- a/lib/cachex/macros/gen_server.ex
+++ b/lib/cachex/macros/gen_server.ex
@@ -9,52 +9,6 @@ defmodule Cachex.Macros.GenServer do
   alias Cachex.Util
 
   @doc """
-  Small macro for detailing handle_call functions, without having to pay attention
-  to the syntax. You can simply define them as `defcall my_func(arg1) do:` as an
-  example. There is no support for guards, but no logic happens inside the worker
-  with regards to arguments anyway.
-  """
-  defmacro defcall(head, do: body) do
-    { func_name, args } = Macros.name_and_args(head)
-
-    quote do
-      def handle_call({ unquote(func_name), unquote_splicing(args) }, _, var!(state)) do
-        unquote(body) |> Util.reply(var!(state))
-      end
-    end
-  end
-
-  @doc """
-  Small macro for detailing handle_cast functions, without having to pay attention
-  to the syntax. You can simply define them as `defcast my_func(arg1) do:` as an
-  example. There is no support for guards, but no logic happens inside the worker
-  with regards to arguments anyway.
-  """
-  defmacro defcast(head, do: body) do
-    { func_name, args } = Macros.name_and_args(head)
-
-    quote do
-      def handle_cast({ unquote(func_name), unquote_splicing(args) }, var!(state)) do
-        unquote(body) |> Util.noreply(var!(state))
-      end
-    end
-  end
-
-  @doc """
-  Very small wrapper around handle_info calls so you can define your own message
-  handler with little effort. Again nothing special, but saves on boilerplate.
-  """
-  defmacro definfo(head, do: body) do
-    { func_name, _ } = Macros.name_and_args(head)
-
-    quote do
-      def handle_info(unquote(func_name), var!(state)) do
-        unquote(body)
-      end
-    end
-  end
-
-  @doc """
   Generates a simple delegate binding for GenServer methods. This is in case the
   raw function is provided in the module and it should be accessible via the server
   as well.
@@ -77,16 +31,16 @@ defmodule Cachex.Macros.GenServer do
 
     called_quote = if call do
       quote do
-        defcall unquote(func_name)(unquote_splicing(args_without_state)) do
-          unquote(func_name)(unquote_splicing(args))
+        def handle_call({ unquote(func_name), unquote_splicing(args_without_state) }, _, var!(state)) do
+          unquote(func_name)(unquote_splicing(args)) |> Util.reply(var!(state))
         end
       end
     end
 
     casted_quote = if cast do
       quote do
-        defcast unquote(func_name)(unquote_splicing(args_without_state)) do
-          unquote(func_name)(unquote_splicing(args))
+        def handle_cast({ unquote(func_name), unquote_splicing(args_without_state) }, var!(state)) do
+          unquote(func_name)(unquote_splicing(args)) |> Util.noreply(var!(state))
         end
       end
     end


### PR DESCRIPTION
This relates back to #3 and adds the ability to view the results of the last Janitor run.

These three values are maintained:

- the last time the Janitor check started
- the duration of the last Janitor run
- the total number of entries purged in the last run

I think this should be enough to keep an eye on Janitors so I'm ready to merge. I may add more in future, but for now I believe this is sufficient.