### PR TITLE
Add a stream/2 function to the interface

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -1018,6 +1018,46 @@ defmodule Cachex do
   end
 
   @doc """
+  Returns a Stream which can be used to iterate through a cache.
+
+  This operates entirely on an ETS level in order to provide a moving view of the
+  cache. As such, if you wish to operate on any keys as a result of this Stream,
+  please buffer them up and execute using `transaction/3`.
+
+  ## Options
+
+    * `:only` - either `:keys` or `:values`, to return only the specified field.
+      If unset, you will receive a tuple of `{ key, value }`.
+    * `:timeout` - the timeout for any calls to the worker.
+
+  ## Examples
+
+      iex> Cachex.set(:my_cache, "a", 1)
+      iex> Cachex.set(:my_cache, "b", 2)
+      iex> Cachex.set(:my_cache, "c", 3)
+      {:ok, true}
+
+      iex> :my_cache |> Cachex.stream! |> Enum.to_list
+      [{"b", 2}, {"c", 3}, {"a", 1}]
+
+      iex> :my_cache |> Cachex.stream!(only: :keys) |> Enum.to_list
+      ["b", "c", "a"]
+
+      iex> :my_cache |> Cachex.stream!(only: :values) |> Enum.to_list
+      [2, 3, 1]
+
+  """
+  @spec stream(cache, options) :: { status, Enumerable.t }
+  defwrap stream(cache, options \\ []) when is_list(options) do
+    do_action(cache, fn
+      (cache) when is_atom(cache) ->
+        GenServer.call(cache, { :stream, options }, timeout(options))
+      (cache) ->
+        Worker.stream(cache, options)
+    end)
+  end
+
+  @doc """
   Takes a key from the cache.
 
   This is equivalent to running `get/3` followed by `del/3` in a single action.

--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -1026,8 +1026,9 @@ defmodule Cachex do
 
   ## Options
 
-    * `:only` - either `:keys` or `:values`, to return only the specified field.
-      If unset, you will receive a tuple of `{ key, value }`.
+    * `:of` - allows you to return a stream of a custom format, however usually
+      only `:key` or `:value` will be needed. If unset, you will receive a tuple
+      of `{ :key, :value }`.
     * `:timeout` - the timeout for any calls to the worker.
 
   ## Examples
@@ -1040,11 +1041,14 @@ defmodule Cachex do
       iex> :my_cache |> Cachex.stream! |> Enum.to_list
       [{"b", 2}, {"c", 3}, {"a", 1}]
 
-      iex> :my_cache |> Cachex.stream!(only: :keys) |> Enum.to_list
+      iex> :my_cache |> Cachex.stream!(of: :key) |> Enum.to_list
       ["b", "c", "a"]
 
-      iex> :my_cache |> Cachex.stream!(only: :values) |> Enum.to_list
+      iex> :my_cache |> Cachex.stream!(of: :value) |> Enum.to_list
       [2, 3, 1]
+
+      iex> :my_cache |> Cachex.stream!(of: { :key, :ttl }) |> Enum.to_list
+      [{"b", nil}, {"c", nil}, {"a", nil}]
 
   """
   @spec stream(cache, options) :: { status, Enumerable.t }

--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -1027,8 +1027,8 @@ defmodule Cachex do
   ## Options
 
     * `:of` - allows you to return a stream of a custom format, however usually
-      only `:key` or `:value` will be needed. If unset, you will receive a tuple
-      of `{ :key, :value }`.
+      only `:key` or `:value` will be needed. This can be an atom or a tuple and
+      defaults to using `{ :key, :value }` if unset.
     * `:timeout` - the timeout for any calls to the worker.
 
   ## Examples

--- a/lib/cachex/inspector.ex
+++ b/lib/cachex/inspector.ex
@@ -44,7 +44,7 @@ defmodule Cachex.Inspector do
   end
   def inspect(cache, { :expired, :keys }) do
     query =
-      :"$1"
+      :key
       |> Util.retrieve_expired_rows
 
     cache

--- a/lib/cachex/worker.ex
+++ b/lib/cachex/worker.ex
@@ -308,14 +308,10 @@ defmodule Cachex.Worker do
     do_action(state, { :stream, options }, fn ->
       stream = Stream.resource(
         fn ->
-          match_spec = Util.retrieve_all_rows(case options[:only] do
-            :keys ->
-              :"$1"
-            :values ->
-              :"$4"
-            _others ->
-              {{ :"$1", :"$4" }}
-          end)
+          match_spec =
+            options
+            |> Keyword.get(:of, { :key, :value })
+            |> Util.retrieve_all_rows
 
           state.cache
           |> :ets.table([ { :traverse, { :select, match_spec } }])

--- a/lib/cachex/worker/local.ex
+++ b/lib/cachex/worker/local.ex
@@ -88,7 +88,7 @@ defmodule Cachex.Worker.Local do
   """
   def keys(state, _options) do
     state.cache
-    |> :ets.select(Util.retrieve_all_rows(:"$1"))
+    |> :ets.select(Util.retrieve_all_rows(:key))
     |> Util.ok
   end
 

--- a/lib/cachex/worker/remote.ex
+++ b/lib/cachex/worker/remote.ex
@@ -76,7 +76,7 @@ defmodule Cachex.Worker.Remote do
   """
   def keys(state, _options) do
     state.cache
-    |> :mnesia.dirty_select(Util.retrieve_all_rows(:"$1"))
+    |> :mnesia.dirty_select(Util.retrieve_all_rows(:key))
     |> Util.ok
   end
 

--- a/lib/cachex/worker/transactional.ex
+++ b/lib/cachex/worker/transactional.ex
@@ -89,7 +89,7 @@ defmodule Cachex.Worker.Transactional do
   """
   def keys(state, _options) do
     Util.handle_transaction(fn ->
-      :mnesia.select(state.cache, Util.retrieve_all_rows(:"$1"))
+      :mnesia.select(state.cache, Util.retrieve_all_rows(:key))
     end)
   end
 

--- a/test/cachex_test/stream.exs
+++ b/test/cachex_test/stream.exs
@@ -1,0 +1,101 @@
+defmodule CachexTest.Stream do
+  use PowerAssert
+
+  setup do
+    { :ok, cache: TestHelper.create_cache() }
+  end
+
+  test "stream requires an existing cache name", _state do
+    assert(Cachex.stream("test") == { :error, "Invalid cache provided, got: \"test\"" })
+  end
+
+  test "stream with a worker instance", state do
+    state_result = Cachex.inspect!(state.cache, :worker)
+    assert(Cachex.stream!(state_result) |> Enum.to_list == [])
+  end
+
+  test "stream returns a stream of keys and values", state do
+    Enum.each(1..3, fn(x) ->
+      set_result = Cachex.set(state.cache, "key#{x}", "value#{x}")
+      assert(set_result == { :ok, true })
+    end)
+
+    { status, stream } = Cachex.stream(state.cache)
+
+    assert(status == :ok)
+
+    sorted_stream =
+      stream
+      |> Enum.sort
+      |> Enum.to_list
+
+      assert(sorted_stream == [
+        {"key1", "value1"},
+        {"key2", "value2"},
+        {"key3", "value3"}
+      ])
+  end
+
+  test "stream returns a stream of only keys", state do
+    Enum.each(1..3, fn(x) ->
+      set_result = Cachex.set(state.cache, "key#{x}", "value#{x}")
+      assert(set_result == { :ok, true })
+    end)
+
+    { status, stream } = Cachex.stream(state.cache, only: :keys)
+
+    assert(status == :ok)
+
+    sorted_stream =
+      stream
+      |> Enum.sort
+      |> Enum.to_list
+
+    assert(sorted_stream == ["key1", "key2", "key3"])
+  end
+
+  test "stream returns a stream of only values", state do
+    Enum.each(1..3, fn(x) ->
+      set_result = Cachex.set(state.cache, "key#{x}", "value#{x}")
+      assert(set_result == { :ok, true })
+    end)
+
+    { status, stream } = Cachex.stream(state.cache, only: :values)
+
+    assert(status == :ok)
+
+    sorted_stream =
+      stream
+      |> Enum.sort
+      |> Enum.to_list
+
+    assert(sorted_stream == ["value1", "value2", "value3"])
+  end
+
+  test "stream returns a moving view of a cache", state do
+    Enum.each(1..3, fn(x) ->
+      set_result = Cachex.set(state.cache, "key#{x}", "value#{x}")
+      assert(set_result == { :ok, true })
+    end)
+
+    { status, stream } = Cachex.stream(state.cache)
+
+    assert(status == :ok)
+
+    set_result = Cachex.set(state.cache, "key4", "value4")
+    assert(set_result == { :ok, true })
+
+    sorted_stream =
+      stream
+      |> Enum.sort
+      |> Enum.to_list
+
+    assert(sorted_stream == [
+      {"key1", "value1"},
+      {"key2", "value2"},
+      {"key3", "value3"},
+      {"key4", "value4"}
+    ])
+  end
+
+end

--- a/test/cachex_test/stream.exs
+++ b/test/cachex_test/stream.exs
@@ -42,7 +42,7 @@ defmodule CachexTest.Stream do
       assert(set_result == { :ok, true })
     end)
 
-    { status, stream } = Cachex.stream(state.cache, only: :keys)
+    { status, stream } = Cachex.stream(state.cache, of: :key)
 
     assert(status == :ok)
 
@@ -60,7 +60,7 @@ defmodule CachexTest.Stream do
       assert(set_result == { :ok, true })
     end)
 
-    { status, stream } = Cachex.stream(state.cache, only: :values)
+    { status, stream } = Cachex.stream(state.cache, of: :value)
 
     assert(status == :ok)
 
@@ -96,6 +96,28 @@ defmodule CachexTest.Stream do
       {"key3", "value3"},
       {"key4", "value4"}
     ])
+  end
+
+  test "stream returns a stream of custom types", state do
+    Enum.each(1..3, fn(x) ->
+      set_result = Cachex.set(state.cache, "key#{x}", "value#{x}")
+      assert(set_result == { :ok, true })
+    end)
+
+    { status, stream } = Cachex.stream(state.cache, of: { :value, :key, :ttl })
+
+    assert(status == :ok)
+
+    sorted_stream =
+      stream
+      |> Enum.sort
+      |> Enum.to_list
+
+      assert(sorted_stream == [
+        {"value1", "key1", nil},
+        {"value2", "key2", nil},
+        {"value3", "key3", nil}
+      ])
   end
 
 end

--- a/test/cachex_test/util.exs
+++ b/test/cachex_test/util.exs
@@ -241,11 +241,6 @@ defmodule CachexTest.Util do
     assert(Util.last_of_tuple({}) == nil)
   end
 
-  test "util.list_to_tuple/1 converts a list to a tuple" do
-    assert(Util.list_to_tuple([ :one, :two, :three ]) == { :one, :two, :three })
-    assert(Util.list_to_tuple([]) == {})
-  end
-
   test "util.retrieve_all_rows/1 returns a select on all rows" do
     [ { variables, condition, result } ] =
       true


### PR DESCRIPTION
This PR introduces a new `stream/2` function which will return a Stream of the underlying ETS table. This Stream can then be used to iterate through all un-expired values quickly using a QLC handle.

In addition, I've included an `:only` option in case you wish to trim down what comes back to just being either keys or values. Default value being passed is `{ key, value }` - I didn't feel a need to raise the entire underlying record... but if anyone requests it in future I may be inclined to tweak.

Please note that this is a moving Stream, meaning it may or may not take new writes into account during traversal. It uses raw ETS as using a transaction would result in all processing having to be done eagerly and inside the cache worker, which is far too expensive and poses an easy-to-do issue with blocking the GenServer. The current implementation allows the iteration of the cache to happen out of proc, which is actually closer to what I imagine people would expect to happen.

This will fix #22 when merged.

**Edit**: I have tweaked `:only` to `:of` in a follow-up commit which allows custom stream formats, with access to all internal fields (even if only `:key` and `:value` will be used). Default stays the same. I also added aliases throughout to help with match specs, instead of having to provide `:"$1"` & co. which are quite fiddly to type.