### PR TITLE
Ensure Hooks are linked to the Cachex Supervisor

### DIFF
--- a/lib/cachex/hook.ex
+++ b/lib/cachex/hook.ex
@@ -10,6 +10,12 @@ defmodule Cachex.Hook do
   # needed. You can also define that the results of the command are provided to
   # post-hooks, in case you wish to use the results in things such as log messages.
 
+  # add aliases
+  alias Cachex.Options
+  alias Cachex.Worker
+  alias Supervisor.Spec
+
+  # define our struct
   defstruct args: [],
             async: true,
             max_timeout: 5,
@@ -29,50 +35,10 @@ defmodule Cachex.Hook do
   def initialize_hooks(mods) do
     mods
     |> List.wrap
-    |> Enum.map(fn
-        (%__MODULE__{ } = hook) -> hook
-        (_) -> nil
-       end)
-    |> Enum.map(&(start_hook/1))
+    |> Enum.map(&verify_hook/1)
     |> Enum.filter(&(&1 != nil))
     |> Enum.to_list
   end
-
-  # Starts a listener. We check to ensure that the listener is a module before
-  # trying to start it and add as a handler. If anything goes wrong at this point
-  # we just nil the listener to avoid errors later.
-  defp start_hook(%__MODULE__{ } = hook) do
-    try do
-      hook.module.__info__(:module)
-
-      pid = case GenEvent.start_link(hook.server_args) do
-        { :ok, pid } ->
-          GenEvent.add_handler(pid, hook.module, hook.args)
-          pid
-        { :error, { :already_started, pid } } ->
-          Logger.warn(fn ->
-            "Unable to assign hook (server already assigned): #{hook.module}"
-          end)
-          pid
-        _error -> nil
-      end
-
-      case pid do
-        nil -> nil
-        pid -> %__MODULE__{ hook | "ref": pid }
-      end
-    rescue
-      e ->
-        Logger.warn(fn ->
-          """
-          Unable to assign hook (uncaught error): #{inspect(e)}
-          #{Exception.format_stacktrace(System.stacktrace())}
-          """
-        end)
-        nil
-    end
-  end
-  defp start_hook(_), do: nil
 
   @doc """
   Allows for finding a hook by the name of the module. This is only for convenience
@@ -81,11 +47,25 @@ defmodule Cachex.Hook do
   def hook_by_module(hooks, module) do
     hooks
     |> List.wrap
-    |> Enum.find(nil, fn
+    |> Enum.find(fn
         (%__MODULE__{ "module": ^module }) -> true
         (_) -> false
        end)
   end
+
+  @doc """
+  Groups hooks by their execution type (pre/post). We use this to separate the
+  execution phases in order to achieve a smaller iteration at later stages of
+  execution (it saves a microsecond or so).
+  """
+  def hooks_by_type(hooks) do
+    hooks |> List.wrap |> Enum.group_by(%{ pre: [], post: [] }, fn
+      (%__MODULE__{ "type": type }) -> type
+      (_) -> nil
+    end)
+  end
+  def hooks_by_type(hooks, type) when type in [ :pre, :post ],
+  do: hooks_by_type(hooks)[type] || []
 
   @doc """
   Simple shorthanding for pulling the ref of a hook which is found by module. This
@@ -99,24 +79,36 @@ defmodule Cachex.Hook do
   end
 
   @doc """
-  Groups hooks by their execution type (pre/post). We use this to separate the
-  execution phases in order to achieve a smaller iteration at later stages of
-  execution (it saves a microsecond or so).
-  """
-  def hooks_by_type(hooks, type) when type in [ :pre, :post ] do
-    hooks
-    |> List.wrap
-    |> Enum.filter(fn
-        (%__MODULE__{ "type": ^type }) -> true
-        (_) -> false
-       end)
-  end
-
-  @doc """
   Calls a hook instance with the specified message and timeout.
   """
   def call(%__MODULE__{ module: mod, ref: ref }, msg, timeout \\ 5000),
   do: GenEvent.call(ref, mod, msg, timeout)
+
+  @doc """
+  Concatenates the pre and post Hooks of an Options struct.
+  """
+  def combine(%Options{ pre_hooks: pre, post_hooks: post }),
+  do: Enum.concat(pre, post)
+
+  @doc """
+  Iterates a child spec of a Supervisor and maps the process module names to a
+  list of Hook structs. Wherever there is a match, the PID of the child is added
+  to the Hook so that a Hook struct can track where it lives.
+  """
+  def link(children, hooks) when is_list(children) and is_list(hooks) do
+    Enum.map(hooks, fn(%__MODULE__{ "args": args, "module": mod } = hook) ->
+      pid = Enum.find_value(children, fn
+        ({ ^mod, pid, _, _ }) -> pid
+        (_) -> nil
+      end)
+
+      if pid do
+        GenEvent.add_handler(pid, mod, args)
+      end
+
+      %__MODULE__{ hook | "ref": pid }
+     end)
+  end
 
   @doc """
   Provides a single point to call to provision all hooks. We forward the message
@@ -130,6 +122,29 @@ defmodule Cachex.Hook do
   """
   def send(%__MODULE__{ ref: ref }, msg),
   do: Kernel.send(ref, msg)
+
+  @doc """
+  Creates a Supervisor spec of workers for enough GenEvent managers to host all
+  of the provided hooks.
+  """
+  def spec(%Options{ } = options) do
+    options
+    |> combine
+    |> Enum.map(&(Spec.worker(GenEvent, [&1.server_args], id: &1.module)))
+  end
+
+  @doc """
+  Updates the provided hooks inside an Options struct. This is used when the PID
+  of hooks have changed and need to be blended into the Options.
+  """
+  def update(hooks, %Worker{ options: options } = worker) do
+    with %{ pre: pre, post: post } <- hooks_by_type(hooks) do
+      %Worker {
+        worker |
+        options: %Options { options | pre_hooks: pre, post_hooks: post }
+      }
+    end
+  end
 
   @doc false
   defmacro __using__(_) do
@@ -163,6 +178,8 @@ defmodule Cachex.Hook do
         send(ref, { :ack, self, msg })
         res
       end
+      def handle_event({ :reset, args }, state),
+      do: apply(__MODULE__, :init, args)
       def handle_event(_msg, state) do
         {:ok, state}
       end
@@ -196,8 +213,6 @@ defmodule Cachex.Hook do
       # argument, rather than passing through a tuple of message and results.
       defp delegate_notify(event, state) do
         case event do
-          { :reset_hook, args } when is_list(args) ->
-            apply(__MODULE__, :init, args)
           { msg, result } when is_tuple(msg) and is_tuple(result) ->
             handle_notify(msg, result, state)
           other ->
@@ -219,5 +234,24 @@ defmodule Cachex.Hook do
       ]
     end
   end
+
+  # Verifies a listener. We check to ensure that the listener is a module before
+  # trying to start it and add as a handler. If anything goes wrong at this point
+  # we just nil the listener to avoid errors later.
+  defp verify_hook(%__MODULE__{ } = hook) do
+    try do
+      hook.module.__info__(:module) && hook
+    rescue
+      e ->
+        Logger.warn(fn ->
+          """
+          Unable to assign hook (uncaught error): #{inspect(e)}
+          #{Exception.format_stacktrace(System.stacktrace())}
+          """
+        end)
+        nil
+    end
+  end
+  defp verify_hook(_), do: nil
 
 end

--- a/lib/cachex/janitor.ex
+++ b/lib/cachex/janitor.ex
@@ -29,15 +29,6 @@ defmodule Cachex.Janitor do
   end
 
   @doc """
-  Same as `start_link/2` however this function does not link to the calling process.
-  """
-  def start(options \\ %Cachex.Options { }, gen_options \\ []) do
-    if options.ttl_interval do
-      GenServer.start(__MODULE__, options, gen_options)
-    end
-  end
-
-  @doc """
   Main initialization phase of a janitor, creating a stats struct as required and
   creating the initial state for this janitor. The state is then passed through
   for use in the future.

--- a/test/cachex_test/hook.exs
+++ b/test/cachex_test/hook.exs
@@ -158,39 +158,6 @@ defmodule CachexTest.Hook do
     assert(worker_state.actions == Cachex.Worker.Remote)
   end
 
-  test "hooks with multiple hooks per server", state do
-    hooks = [
-      %Cachex.Hook{
-        args: self(),
-        async: false,
-        module: CachexTest.Hook.TestHook,
-        results: true,
-        server_args: [
-          name: :test_multiple_hooks
-        ],
-        type: :post
-      },
-      %Cachex.Hook{
-        args: self(),
-        async: false,
-        module: CachexTest.Hook.SecondTestHook,
-        results: true,
-        server_args: [
-          name: :test_multiple_hooks
-        ],
-        type: :post
-      }
-    ]
-
-    io_output = capture_log(fn ->
-      Cachex.start_link([ name: state.name, hooks: hooks ])
-    end)
-
-    expected_pattern = ~r/Unable to assign hook \(server already assigned\): Elixir\.CachexTest\.Hook\.SecondTestHook/
-
-    assert(String.match?(io_output, expected_pattern))
-  end
-
   test "hooks with invalid module provided", state do
     hooks = [
       %Cachex.Hook{
@@ -221,7 +188,7 @@ defmodule CachexTest.Hook do
     expected_pattern = ~r/    CachexTest\.Hook\.FakeHook\.__info__\(:module\)/
     assert(String.match?(line, expected_pattern))
 
-    expected_pattern = ~r/    \(cachex\) lib\/cachex\/hook\.ex:\d+: Cachex.Hook.start_hook\/1/
+    expected_pattern = ~r/    \(cachex\) lib\/cachex\/hook\.ex:\d+: Cachex.Hook.verify_hook\/1/
     assert(String.match?(context, expected_pattern))
   end
 


### PR DESCRIPTION
This PR will resolve #32. Hooks will now be supervised by the Cachex supervisor rather than being linked to the calling process. This fixes an issue when you create a cache from a spawned process and all hooks immediately die due to the links.

I've also stripped out the internal `start/2` functions of both `Cachex.Worker` and `Cachex.Janitor` and made `Cachex.start/2` far more elegant (as it was actually broken previously).

In addition, there's some general cleanup of public functions which should've been private.