### PR TITLE
Fix mix command line calls in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,10 +440,10 @@ If you feel something can be improved, or have any questions about certain behav
 If you *do* make changes to the codebase, please make sure you test your changes thoroughly, and include any unit tests alongside new or changed behaviours. Cachex currently uses the excellent [excoveralls](https://github.com/parroty/excoveralls) to track code coverage.
 
 ```bash
-$ mix cachex test
-$ mix cachex credo
-$ mix cachex coveralls
-$ mix cachex coveralls.html && open cover/excoveralls.html
+$ mix test
+$ mix credo
+$ mix coveralls
+$ mix coveralls.html && open cover/excoveralls.html
 ```
 
 Note that any test-related tasks should be executed under the `cachex` task in order to gain the required context. The first argument is the name of the task to run, and any arguments afterwards are passed as they appear.


### PR DESCRIPTION
This is coming along nicely :+1:

One thing I noticed: It seems to me these command line calls are off, as there is no `mix cachex` task after cloning and compiling the project.