### PR TITLE
Add the initial implementation of LRW evictions

### DIFF
--- a/lib/cachex/hook.ex
+++ b/lib/cachex/hook.ex
@@ -20,7 +20,7 @@ defmodule Cachex.Hook do
   # define our struct
   defstruct args: [],
             async: true,
-            max_timeout: 5,
+            max_timeout: nil,
             module: nil,
             ref: nil,
             provide: [],
@@ -260,7 +260,13 @@ defmodule Cachex.Hook do
   # we just nil the listener to avoid errors later.
   defp verify_hook(%__MODULE__{ } = hook) do
     try do
-      hook.module.__info__(:module) && hook
+      hook.module.__info__(:module)
+
+      if !hook.async && !hook.max_timeout do
+        %__MODULE__{ hook | max_timeout: 5 }
+      else
+        hook
+      end
     rescue
       e ->
         Logger.warn(fn ->

--- a/lib/cachex/limit.ex
+++ b/lib/cachex/limit.ex
@@ -1,0 +1,75 @@
+defmodule Cachex.Limit do
+  @moduledoc false
+  # This module defines the Limit struct used to signify any cache limits with
+  # regards to the bounds of the cache. Currently this struct stores the maximum
+  # amount of cache entries, a policy to use when evicting entries, and a percentage
+  # of the cache to reclaim.
+
+  # add a policy alias
+  alias Cachex.Policy
+
+  # internal limit struct
+  defstruct [
+    limit:   nil,               # the limit to apply (entry count)
+    policy:  Policy.LRW,        # the module to handle
+    reclaim: 0.1                # the amount of the cache to reclaim
+  ]
+
+  # our opaque type
+  @opaque t :: %__MODULE__{ }
+
+  # define limit types
+  @type limit :: Limit.t
+  @type limit_total :: number
+
+  @doc """
+  Parses an input into a Limit struct.
+
+  Acceptable values are a preconstructed limit, or a maximum count. In the latter
+  case, the LRW policy will be used with a 10% reclaim space.
+  """
+  @spec parse(limit :: (limit | limit_total)) :: limit :: limit
+  def parse(%__MODULE__{ limit: limit, policy: policy, reclaim: reclaim }),
+    do: parse_limit(limit, policy, reclaim)
+  def parse(limit),
+    do: parse_limit(limit)
+
+  @doc """
+  Converts a Limit struct to the required Hook form.
+
+  Limits function as hooks inside a cache (at this point in time), and as such,
+  this function is just sugar to do the conversion on a given Limit structure.
+  """
+  @spec to_hooks(limit :: limit) :: limit_hook :: Hook.t
+  def to_hooks(%__MODULE__{ limit: nil }) do
+    [ ]
+  end
+  def to_hooks(%__MODULE__{ limit: limit, policy: policy, reclaim: reclaim }) do
+    [
+      %Cachex.Hook{
+        args: { limit, reclaim },
+        module: policy,
+        results: true,
+        provide: [ :worker ],
+        type: :post
+      }
+    ]
+  end
+
+  # Internal parser for a Limit to ensure that we don't waste any cycles checking
+  # the same constraints multiple times. We apply defaults for any values which
+  # don't fit the necessary criteria.
+  defp parse_limit(limit, policy \\ Policy.LRW, reclaim \\ 0.1) do
+    %__MODULE__{
+      limit:   v_parse(:limit,   limit,   &(is_number(&1) and &1 > 0)),
+      policy:  v_parse(:policy,  policy,  &Policy.valid?/1),
+      reclaim: v_parse(:reclaim, reclaim, &(is_number(&1) and &1 > 0 and &1 <= 1))
+    }
+  end
+
+  # Internal value parser which falls back to using defaults in the scenario the
+  # provided value is invalid based upon the provided condition.
+  defp v_parse(key, val, condition),
+  do: condition.(val) && val || Map.get(%__MODULE__{ }, key)
+
+end

--- a/lib/cachex/policy.ex
+++ b/lib/cachex/policy.ex
@@ -1,0 +1,16 @@
+defmodule Cachex.Policy do
+  @moduledoc false
+  # This module contains grace functions around internal eviction policies.
+  # Currently very little exists in here beyond a centralized list of known modules
+  # which can act as eviction policies when using inside a cache Limit.
+
+  # our known policies
+  @policies [ Cachex.Policy.LRW ]
+
+  @doc """
+  Returns whether a policy is known or not.
+  """
+  @spec valid?(policy :: atom) :: true | false
+  def valid?(policy), do: policy in @policies
+
+end

--- a/lib/cachex/policy/lrw.ex
+++ b/lib/cachex/policy/lrw.ex
@@ -1,0 +1,185 @@
+defmodule Cachex.Policy.LRW do
+  @moduledoc false
+  # This module provides an eviction policy for Cachex, evicting the least-recently
+  # written entries from the cache. This is determined by the touched time inside
+  # each cache record, which means that this eviction is almost zero cost, consuming
+  # no additional memory beyond that of the running GenServer.
+  #
+  # This policy accepts a reclaim space to determine how much of the cache to evict,
+  # allowing the user to determine exactly how much they'd like to trim in the event
+  # they've gone over the limit.
+  #
+  # This eviction is relatively fast, and should keep the cache below bounds at most
+  # times. Note that many writes in a very short amount of time can flood the cache,
+  # but it should recover given a few seconds.
+
+  # use the hook system
+  use Cachex.Hook
+
+  # add internal aliases
+  alias Cachex.Util
+  alias Cachex.Worker
+
+  # store a list of actions which add items to the cache, as we only need to then
+  # operate on these actions - this allows us to optimize and avoid checking size
+  # when there's no chance of a size change since the last check
+  @additives MapSet.new([ :set, :update, :incr, :get_and_update, :decr ])
+
+  # batch size to delete with
+  @del_count 50
+
+  # compile our QLC match at runtime to avoid recalculating
+  @qlc_match Util.create_match([ { { :"$1", :"$2" } } ], [ ])
+
+  @doc """
+  Initializes the policy, accepting a maximum size and a bound to trim by.
+
+  We store a state of the maximum size, and a calculated number to trim to.
+  """
+  def init({ max_size, trim_bound }) do
+    { :ok, { max_size, round(max_size * trim_bound), nil } }
+  end
+
+  @doc """
+  Checks and enforces the bounds of the cache as needed.
+
+  This notification will receive all actions taken by the cache, and uses them to
+  determine when to trim the cache. We only operate on results which have not had
+  an error, and whose actions are listed in the additives constant (as only actions)
+  fitting this criteria can have a net gain in cache size.
+  """
+  def handle_notify(action, { status, _value }, opts) when status != :error do
+    if MapSet.member?(@additives, elem(action, 0)) do
+      enforce_bounds(opts)
+    end
+    { :ok, opts }
+  end
+
+  @doc """
+  Retrieves a provisioned worker from the cache and stores it inside the state.
+
+  This worker is then used going forward for any cache calls to avoid the overhead
+  of looking up the state. Again an optimization.
+  """
+  def handle_info({ :provision, { :worker, worker } }, { max_size, trim_bound, _worker }) do
+    { :ok, { max_size, trim_bound, worker } }
+  end
+
+  # Suggest stepping through this pipeline a function at a time and reading the
+  # associated comments. This pipeline controls the trimming of the cache to fit
+  # the appropriate size.
+  #
+  # We start with the current size of the cache and pass it through to a function
+  # which will calculate the a number of slots to reclaim in the cache. If the
+  # number is positive, we carry out a Janitor purge and see if that brings us
+  # back under the maximum size. If so, we're done and stop. If not, we then trim
+  # the cache using a QLC cursor through the cache, deleting entries in batches.
+  # Note that these deletions are sorted by the touch time to ensure we delete
+  # the oldest first.
+  #
+  # Upon completion, we notify the worker itself to broadcast a message to all
+  # hooks to ensure that hooks are notified of the evictions. This is only done
+  # in the case that something has actually been removed, in order to avoid edge
+  # cases and potentially breaking existing hook implementations.
+  #
+  # It's safe to always run through the pipeline here, but we check the cache
+  # size as an optimization to speed up message processing when no evictions need
+  # to happen. This is a slight speed boost, but it's noticeable - tests will fail
+  # intermittently if this is not checked in this way.
+  defp enforce_bounds({ max_size, reclaim_bound, state }) do
+    case Cachex.size!(state, [ notify: false ]) do
+      cache_size when cache_size <= max_size ->
+        notify_worker(0, state)
+      cache_size ->
+        cache_size
+        |> calculate_reclaim(max_size, reclaim_bound)
+        |> calculate_poffset(state)
+        |> erase_lower_bound(state)
+        |> notify_worker(state)
+    end
+  end
+
+  # Calculates the space to reclaim inside the cache, based on the maximum cache
+  # size, the reclaim bound, and the current size of the cache. A positive result
+  # from this function means we need to carry out evictions, whereas a negative
+  # means that the cache is currently underpopulated.
+  defp calculate_reclaim(current_size, max_size, reclaim_bound) do
+    (max_size - reclaim_bound - current_size) * -1
+  end
+
+  # Calculates the purge offset of the cache. Basically this means that if the
+  # cache is overpopulated, we would trigger a Janitor purge to see if it brings
+  # us back under the cache limit. The resulting amount to remove is then returned.
+  # Again, a positive result means that we still have evictions to carry out.
+  defp calculate_poffset(reclaim_space, state) when reclaim_space > 0 do
+    reclaim_space - Cachex.purge!(state)
+  end
+
+  # This is the cuts of the cache trimming. If the provided offset is negative,
+  # it means that the cache is within the maximum size and so we just pass through
+  # as a no-op.
+  #
+  # In the case that it's positive, it represents the number of items to remove
+  # from the cache. We do this by using a traversal of the underlying ETS table,
+  # which only selects the key and touch time. The key is obviously required when
+  # it comes to removing the document, and the touch time is used to determine
+  # the sorted order required for implementing LRW. We transform this sort using
+  # a QLC cursor and pass it through to `erase_cursor/3` to delete.
+  defp erase_lower_bound(offset, %{ cache: cache }) when offset > 0 do
+    cache
+    |> :ets.table([ traverse: { :select, @qlc_match } ])
+    |> :qlc.sort([ order: fn({ _k1, t1 }, { _k2, t2  }) -> t1 < t2 end ])
+    |> :qlc.cursor
+    |> erase_cursor(cache, offset)
+
+    offset
+  end
+  defp erase_lower_bound(offset, _state) do
+    offset
+  end
+
+  # This function erases a QLC cursor by taking in a provided cursor and removing
+  # the first N elements from the cursor. Removals are done in batches according
+  # to the compiled constant @del_count.
+  #
+  # This is a recursive function as we have to keep track of the number to remove,
+  # as the removal is done by calling `erase_batch/3`. At the end of the recursion,
+  # we make sure to remove the trailing QLC cursor to avoid leaving it around.
+  defp erase_cursor(cursor, table, remaining) when remaining > @del_count do
+    erase_batch(cursor, table, @del_count)
+    erase_cursor(cursor, table, remaining - @del_count)
+  end
+  defp erase_cursor(cursor, table, remaining) do
+    erase_batch(cursor, table, remaining)
+    :qlc.delete_cursor(cursor)
+  end
+
+  # Erases a batch of entries from the table. We pull the next batch of entries
+  # from the table and erase them by key. This is not as efficient as using the
+  # `:ets.select_delete/2` function but is required due to the cursored sort.
+  defp erase_batch(cursor, table, amount) do
+    for { key, _touched } <- :qlc.next_answers(cursor, amount) do
+      :ets.delete(table, key)
+    end
+  end
+
+  # At the end of the pipeline we broadcast the eviction count to any listening
+  # hooks. Remember that it's important that we're ignoring `clear/1` calls in
+  # this hook, as otherwise we'd execute a check immediately after (on our report).
+  # If the offset is not positive, we don't broadcast - meaning that we didn't
+  # have to remove anything from the cache (the no-op from the above definitions).
+  # It returns a tuple simply to keep compatibility with the return type coming
+  # from `Worker.broadcast/3`.
+  #
+  # It should be noted that we use a `:clear` action here as these evictions are
+  # based on size and not on TTL. The evictions done during the purge earlier in
+  # the pipeline are reported separately and we're only reporting the delta at this
+  # point in time.
+  defp notify_worker(offset, state) when offset > 0 do
+    Worker.broadcast(state, { :clear, [] }, { :ok, offset })
+  end
+  defp notify_worker(_offset, _state) do
+    { :ok, 0 }
+  end
+
+end

--- a/lib/cachex/state.ex
+++ b/lib/cachex/state.ex
@@ -17,6 +17,7 @@ defmodule Cachex.State do
             default_ttl: nil,       # any default ttl values to use
             fallback_args: nil,     # arguments to pass to a cache loader
             janitor: nil,           # the name of the janitor attached (if any)
+            limit: nil,             # any limit to apply to the cache
             pre_hooks: nil,         # any pre hooks to attach
             post_hooks: nil,        # any post hooks to attach
             ttl_interval: nil       # the ttl check interval

--- a/test/cachex/hook_test.exs
+++ b/test/cachex/hook_test.exs
@@ -3,8 +3,6 @@ defmodule Cachex.HookTest do
 
   import ExUnit.CaptureLog
 
-  @testhost Cachex.Util.create_node_name("cachex_test")
-
   setup do
     { :ok, name: String.to_atom(TestHelper.gen_random_string_of_length(16)) }
   end
@@ -31,7 +29,6 @@ defmodule Cachex.HookTest do
     hooks = %Cachex.Hook{
       args: self(),
       async: true,
-      max_timeout: 250,
       module: Cachex.HookTest.TestHook,
       type: :pre
     }
@@ -60,6 +57,28 @@ defmodule Cachex.HookTest do
     end)
 
     assert(sync_time > 5000 && sync_time < 7500)
+  end
+
+  test "hooks default asynchronous timeouts to nil", _state do
+    [hook] = Cachex.Hook.initialize_hooks(%Cachex.Hook{
+      args: self(),
+      async: true,
+      module: Cachex.HookTest.TestHook,
+      type: :pre
+    })
+
+    assert(hook.max_timeout == nil)
+  end
+
+  test "hooks default synchronous timeouts to 5ms", _state do
+    [hook] = Cachex.Hook.initialize_hooks(%Cachex.Hook{
+      args: self(),
+      async: false,
+      module: Cachex.HookTest.TestHook,
+      type: :pre
+    })
+
+    assert(hook.max_timeout == 5)
   end
 
   test "hooks with synchronous notifications have minimal overhead", state do

--- a/test/cachex/limit_test.exs
+++ b/test/cachex/limit_test.exs
@@ -1,0 +1,96 @@
+defmodule Cachex.LimitTest do
+  use PowerAssert, async: false
+
+  test "parsing a limit using an existing limit" do
+    limit = %Cachex.Limit{
+      limit: 500,
+      policy: Cachex.Policy.LRW,
+      reclaim: 0.3
+    }
+
+    assert(Cachex.Limit.parse(limit) == limit)
+  end
+
+  test "parsing a limit using an entry count" do
+    assert(Cachex.Limit.parse(500) == %Cachex.Limit{
+      limit: 500,
+      policy: Cachex.Policy.LRW,
+      reclaim: 0.1
+    })
+  end
+
+  test "parsing a limit using an invalid value" do
+    assert(Cachex.Limit.parse(:missing) == %Cachex.Limit{
+      limit: nil,
+      policy: Cachex.Policy.LRW,
+      reclaim: 0.1
+    })
+  end
+
+  test "parsing a limit using an invalid policy" do
+    limit = %Cachex.Limit{
+      limit: 500,
+      policy: Cachex.Policy.Missing,
+      reclaim: 0.3
+    }
+
+    assert(Cachex.Limit.parse(limit) == %Cachex.Limit{
+      limit: 500,
+      policy: Cachex.Policy.LRW,
+      reclaim: 0.3
+    })
+  end
+
+  test "parsing a limit using an invalid upper reclaim bound" do
+    limit = %Cachex.Limit{
+      limit: 500,
+      policy: Cachex.Policy.Missing,
+      reclaim: 15
+    }
+
+    assert(Cachex.Limit.parse(limit) == %Cachex.Limit{
+      limit: 500,
+      policy: Cachex.Policy.LRW,
+      reclaim: 0.1
+    })
+  end
+
+  test "parsing a limit using an invalid lower reclaim bound" do
+    limit = %Cachex.Limit{
+      limit: 500,
+      policy: Cachex.Policy.Missing,
+      reclaim: -1
+    }
+
+    assert(Cachex.Limit.parse(limit) == %Cachex.Limit{
+      limit: 500,
+      policy: Cachex.Policy.LRW,
+      reclaim: 0.1
+    })
+  end
+
+  test "converting a Limit to a Hook returns a list of hooks" do
+    limit = %Cachex.Limit{
+      limit: 500,
+      policy: Cachex.Policy.LRW,
+      reclaim: 0.3
+    }
+
+    assert(Cachex.Limit.to_hooks(limit) == [ %Cachex.Hook{
+      args: { 500, 0.3 },
+      async: true,
+      max_timeout: nil,
+      module: Cachex.Policy.LRW,
+      provide: [:worker],
+      ref: nil,
+      results: true,
+      server_args: [],
+      type: :post
+    } ])
+  end
+
+  test "converting a nil Limit to a Hook returns an empty list" do
+    assert(Cachex.Limit.to_hooks(%Cachex.Limit{ }) == [ ])
+  end
+
+end

--- a/test/cachex/policy/lrw_test.exs
+++ b/test/cachex/policy/lrw_test.exs
@@ -1,0 +1,165 @@
+defmodule Cachex.Policy.LRWTest do
+  use PowerAssert, async: false
+
+  test "LRW doesn't evict with a nil upper bound" do
+    limit = %Cachex.Limit{
+      limit: nil,
+      policy: Cachex.Policy.LRW,
+      reclaim: 0.1
+    }
+
+    my_cache = TestHelper.create_cache([ limit: limit ])
+
+    Cachex.execute(my_cache, fn(state) ->
+      Enum.each(1..5000, fn(x) ->
+        Cachex.set(state, x, x)
+      end)
+    end)
+
+    assert(Cachex.size!(my_cache) == 5000)
+  end
+
+  test "LRW evicts the oldest entries when the limit is crossed" do
+    limit = %Cachex.Limit{
+      limit: 500,
+      policy: Cachex.Policy.LRW,
+      reclaim: 0.1
+    }
+
+    my_cache = TestHelper.create_cache([ max_size: limit ])
+
+    Cachex.execute(my_cache, fn(state) ->
+      Enum.each(1..500, fn(x) ->
+        Cachex.set(state, x, x)
+      end)
+    end)
+
+    assert(Cachex.size!(my_cache) == 500)
+
+    Cachex.set(my_cache, 501, 501)
+
+    TestHelper.poll(100, 450, fn ->
+      Cachex.size!(my_cache)
+    end)
+  end
+
+  test "LRW evicts a custom number of entries when the limit is crossed" do
+    limit = %Cachex.Limit{
+      limit: 500,
+      policy: Cachex.Policy.LRW,
+      reclaim: 1.0
+    }
+
+    my_cache = TestHelper.create_cache([ max_size: limit ])
+
+    Cachex.execute(my_cache, fn(state) ->
+      Enum.each(1..500, fn(x) ->
+        Cachex.set(state, x, x)
+      end)
+    end)
+
+    assert(Cachex.size!(my_cache) == 500)
+
+    Cachex.set(my_cache, 501, 501)
+
+    TestHelper.poll(1000, 0, fn ->
+      Cachex.size!(my_cache)
+    end)
+  end
+
+  test "LRW doesn't check cache size on non-insert operations" do
+    limit = %Cachex.Limit{
+      limit: 500,
+      policy: Cachex.Policy.LRW,
+      reclaim: 0.5
+    }
+
+    my_cache = TestHelper.create_cache([ max_size: limit ])
+
+    Cachex.execute(my_cache, fn(state) ->
+      Enum.each(1..500, fn(x) ->
+        Cachex.set(state, x, x)
+      end)
+    end)
+
+    assert(Cachex.size!(my_cache) == 500)
+
+    :ets.insert(my_cache, { my_cache, 501, Cachex.Util.now(), nil, 501 })
+
+    assert(Cachex.get!(my_cache, 501) == 501)
+    assert(Cachex.size!(my_cache) == 501)
+
+    Cachex.set(my_cache, 501, 501)
+
+    TestHelper.poll(1000, 250, fn ->
+      Cachex.size!(my_cache)
+    end)
+  end
+
+  test "LRW correctly broadcasts evictions to cache hooks" do
+    limit = %Cachex.Limit{
+      limit: 500,
+      policy: Cachex.Policy.LRW,
+      reclaim: 0.5
+    }
+
+    my_cache = TestHelper.create_cache([
+      max_size: limit,
+      record_stats: true
+    ])
+
+    Cachex.execute(my_cache, fn(state) ->
+      Enum.each(1..500, fn(x) ->
+        Cachex.set(state, x, x)
+      end)
+    end)
+
+    Cachex.set(my_cache, 501, 501)
+
+    TestHelper.poll(1000, 250, fn ->
+      Cachex.size!(my_cache)
+    end)
+
+    stats = Cachex.stats!(my_cache)
+
+    assert(stats.evictionCount == 251)
+  end
+
+  test "LRW purges expired entries before evicting old entries" do
+    limit = %Cachex.Limit{
+      limit: 500,
+      policy: Cachex.Policy.LRW,
+      reclaim: 0.5
+    }
+
+    my_cache = TestHelper.create_cache([
+      max_size: limit,
+      record_stats: true
+    ])
+
+    Cachex.execute(my_cache, fn(state) ->
+      Enum.each(1..251, fn(x) ->
+        Cachex.set(state, x, x, ttl: 1)
+      end)
+    end)
+
+    Cachex.execute(my_cache, fn(state) ->
+      Enum.each(252..500, fn(x) ->
+        Cachex.set(state, x, x)
+      end)
+    end)
+
+    :timer.sleep(5)
+
+    Cachex.set(my_cache, 501, 501)
+
+    TestHelper.poll(1000, 250, fn ->
+      Cachex.size!(my_cache)
+    end)
+
+    stats = Cachex.stats!(my_cache)
+
+    assert(stats.expiredCount == 251)
+  end
+
+end

--- a/test/cachex/policy_test.exs
+++ b/test/cachex/policy_test.exs
@@ -1,0 +1,12 @@
+defmodule Cachex.PolicyTest do
+  use PowerAssert, async: false
+
+  test "checking a valid policy" do
+    assert(Cachex.Policy.valid?(Cachex.Policy.LRW))
+  end
+
+  test "checking an invalid policy" do
+    refute(Cachex.Policy.valid?(Cachex.Policy.Yolo))
+  end
+
+end


### PR DESCRIPTION
This PR relates to #55 by implementing the ability to have a max cache size, which is enforced through a fairly low-cost LRW implementation.

Also introduced are the two new concepts of Limits and Policies.

-A Limit is quite simply a struct containing the Limits of the cache - right now this is just entry count, but I'm toying with an implementation which allows for memory bytes etc.
- A Policy is a ruleset for cache evictions when a Limit is hit. There's no behaviour for implementing these policies yet, but there should be. This will be added in future. Externally pluggable Policies will likely never be available - rather they'll all be internal to Cachex purely because a public interface for this would be difficult to maintain.

The LRW policy is clever in that it operates as a Hook into the cache, and so there's no special handling (which is awesome, no?). As far as this goes, it means that you could write your own Policy if you created a Hook version.

Although this PR doesn't contain documentation, it will come shortly (because this isn't finalised yet).

You can try out this behaviour using the following:

```elixir
# start a cache with a limit of 500 items
# this will erase enough entries to get to 250 left in the cache (reclaim is a percentage to cull)
Cachex.start(:my_cache, [ max_size: %Cachex.Limit{ limit: 500, reclaim: 0.5 } ])

# start a cache with a limit of 500 items
# reclaim defaults to culling 10% of the cache (so you'd be left with 450 entries)
Cachex.start(:my_cache, [ max_size: 500 ])
```