### PR TITLE
Migrate to using { action, [args] } hook messages

### DIFF
--- a/lib/cachex/hook.ex
+++ b/lib/cachex/hook.ex
@@ -26,7 +26,7 @@ defmodule Cachex.Hook do
             provide: [],
             results: false,
             server_args: [],
-            type: :pre
+            type: :post
 
   @doc """
   Starts any required listeners.

--- a/lib/cachex/janitor.ex
+++ b/lib/cachex/janitor.ex
@@ -89,7 +89,7 @@ defmodule Cachex.Janitor do
   # Broadcasts the number of evictions against this purge in order to notify any
   # hooks that a purge has just occurred.
   defp update_evictions({ :ok, evictions } = result, state) when evictions > 0 do
-    Worker.broadcast(state.cache, { :purge, [] }, result)
+    Worker.broadcast(state.cache, { :purge, [[]] }, result)
     state
   end
   defp update_evictions(_other, state), do: state

--- a/lib/cachex/policy/lrw.ex
+++ b/lib/cachex/policy/lrw.ex
@@ -48,8 +48,8 @@ defmodule Cachex.Policy.LRW do
   an error, and whose actions are listed in the additives constant (as only actions)
   fitting this criteria can have a net gain in cache size.
   """
-  def handle_notify(action, { status, _value }, opts) when status != :error do
-    if MapSet.member?(@additives, elem(action, 0)) do
+  def handle_notify({ action, _options }, { status, _value }, opts) when status != :error do
+    if MapSet.member?(@additives, action) do
       enforce_bounds(opts)
     end
     { :ok, opts }
@@ -176,7 +176,7 @@ defmodule Cachex.Policy.LRW do
   # the pipeline are reported separately and we're only reporting the delta at this
   # point in time.
   defp notify_worker(offset, state) when offset > 0 do
-    Worker.broadcast(state, { :clear, [] }, { :ok, offset })
+    Worker.broadcast(state, { :clear, [[]] }, { :ok, offset })
   end
   defp notify_worker(_offset, _state) do
     { :ok, 0 }

--- a/lib/cachex/stats.ex
+++ b/lib/cachex/stats.ex
@@ -27,9 +27,8 @@ defmodule Cachex.Stats do
   We don't keep statistics on requests which errored, to avoid false positives
   about what exactly is going on inside a given cache.
   """
-  def handle_notify(action, { status, _val } = result, stats) when status != :error do
+  def handle_notify({ action, _options }, { status, _val } = result, stats) when status != :error do
     action
-    |> Kernel.elem(0)
     |> Registry.register(result, stats)
     |> Util.ok
   end

--- a/lib/cachex/worker/actions.ex
+++ b/lib/cachex/worker/actions.ex
@@ -15,7 +15,7 @@ defmodule Cachex.Worker.Actions do
   @behaviour Cachex.Worker
 
   # define purge constants
-  @purge_override [{ :via, { :purge } }, { :hook_result, { :ok, 1 } }]
+  @purge_override [{ :via, { :purge, [[]] } }, { :hook_result, { :ok, 1 } }]
 
   @doc """
   Writes a record into the cache, and returns a result signifying whether the

--- a/test/cachex/hook_test.exs
+++ b/test/cachex/hook_test.exs
@@ -212,23 +212,23 @@ end
 defmodule Cachex.HookTest.TestHook do
   use Cachex.Hook
 
-  def handle_notify({ :get, "async_pre_hook", _options }, state) do
+  def handle_notify({ :get, [ "async_pre_hook", _options ] }, state) do
     :timer.sleep(100)
     { :ok, state }
   end
 
-  def handle_notify({ :get, "sync_pre_hook", _options }, state) do
+  def handle_notify({ :get, [ "sync_pre_hook", _options ] }, state) do
     :timer.sleep(100)
     { :ok, state }
   end
 
-  def handle_notify({ :get, "sync_double_hook", _options }, state) do
+  def handle_notify({ :get, [ "sync_double_hook", _options ] }, state) do
     send(state, { :ack, self, 1111 })
     :timer.sleep(100)
     { :ok, state }
   end
 
-  def handle_notify({ :get, "key_without_results", _options }, state) do
+  def handle_notify({ :get, [ "key_without_results", _options ] }, state) do
     { :ok, send(state, "key_without_results") }
   end
 
@@ -236,7 +236,7 @@ defmodule Cachex.HookTest.TestHook do
     { :ok, state }
   end
 
-  def handle_notify({ :get, "key_with_results", _options }, _results, state) do
+  def handle_notify({ :get, [ "key_with_results", _options ] }, _results, state) do
     { :ok, send(state, "key_with_results") }
   end
 

--- a/test/cachex/reset_test.exs
+++ b/test/cachex/reset_test.exs
@@ -29,7 +29,7 @@ defmodule Cachex.ResetTest do
       |> Hook.hook_by_module(__MODULE__.LastActionHook)
 
     hook_state = Hook.call(hook, :state)
-    assert(hook_state == { :size, [] })
+    assert(hook_state == { :size, [[]] })
 
     reset_result = Cachex.reset(cache)
     assert(reset_result == { :ok, true })
@@ -41,7 +41,7 @@ defmodule Cachex.ResetTest do
     assert(size_result == { :ok, 0 })
 
     hook_state = Hook.call(hook, :state)
-    assert(hook_state == { :size, [] })
+    assert(hook_state == { :size, [[]] })
   end
 
   test "resetting only a cache and no hooks" do
@@ -66,13 +66,13 @@ defmodule Cachex.ResetTest do
       |> Hook.hook_by_module(__MODULE__.LastActionHook)
 
     hook_state = Hook.call(hook, :state)
-    assert(hook_state == { :size, [] })
+    assert(hook_state == { :size, [[]] })
 
     reset_result = Cachex.reset(cache, only: :cache)
     assert(reset_result == { :ok, true })
 
     hook_state = Hook.call(hook, :state)
-    assert(hook_state == { :size, [] })
+    assert(hook_state == { :size, [[]] })
 
     size_result = Cachex.size(cache)
     assert(size_result == { :ok, 0 })
@@ -100,7 +100,7 @@ defmodule Cachex.ResetTest do
       |> Hook.hook_by_module(__MODULE__.LastActionHook)
 
     hook_state = Hook.call(hook, :state)
-    assert(hook_state == { :size, [] })
+    assert(hook_state == { :size, [[]] })
 
     reset_result = Cachex.reset(cache, only: :hooks)
     assert(reset_result == { :ok, true })
@@ -140,7 +140,7 @@ defmodule Cachex.ResetTest do
     function_hook = Hook.hook_by_module(pre_hooks, __MODULE__.LastFunctionHook)
 
     action_hook_state = Hook.call(actions_hook, :state)
-    assert(action_hook_state == { :size, [] })
+    assert(action_hook_state == { :size, [[]] })
 
     function_hook_state = Hook.call(function_hook, :state)
     assert(function_hook_state == :size)
@@ -185,8 +185,8 @@ defmodule Cachex.ResetTest.LastFunctionHook do
     { :ok, base }
   end
 
-  def handle_notify(action, _state) do
-    { :ok, elem(action, 0) }
+  def handle_notify({ action, _opts }, _state) do
+    { :ok, action }
   end
 
   def handle_call(:state, state) do


### PR DESCRIPTION
This fixes #59.

There were many places it would be convenient to match on the action taken when working from inside a hook. This was not possible to do in a function head, which made it kinda awkward. It's now possible to do so with the new format of `{ action, args_list }`. This change also guarantees that hook messages are two-element tuples, which is handy. 

In addition, this fixes #60 by tweaking the default hook type to being `:post`. This is reflected in the documentation for the time being, but I'll make it more clear by v2.x release.