### PR TITLE
Add a new touch/3 function

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -875,6 +875,16 @@ defmodule Cachex do
   end
 
   @doc """
+  Touches the last write time on a key.
+
+  This is similar to `refresh/3` except that TTLs are maintained.
+  """
+  @spec touch(cache, any, options) :: { status, true | false }
+  defwrap touch(cache, key, options \\ []) when is_list(options) do
+    do_action(cache, &Actions.Touch.execute(&1, key, options))
+  end
+
+  @doc """
   Transactional equivalent of `execute/3`.
 
   You **must** use the worker instance passed to the provided function when calling

--- a/lib/cachex/actions/touch.ex
+++ b/lib/cachex/actions/touch.ex
@@ -1,0 +1,31 @@
+defmodule Cachex.Actions.Touch do
+  @moduledoc false
+
+  alias Cachex.Actions
+  alias Cachex.Actions.Ttl
+  alias Cachex.LockManager
+  alias Cachex.State
+  alias Cachex.Util
+
+  def execute(%State{ } = state, key, options \\ []) when is_list(options) do
+    Actions.do_action(state, { :touch, [ key, options ] }, fn ->
+      LockManager.write(state, key, fn ->
+        state
+        |> Ttl.execute(key, notify: false)
+        |> handle_ttl(state, key)
+      end)
+    end)
+  end
+
+  defp handle_ttl({ :missing, nil }, _state, _key) do
+    { :missing, false }
+  end
+
+  defp handle_ttl({ :ok, nil }, state, key) do
+    Actions.update(state, key, [{ 2, Util.now() }])
+  end
+  defp handle_ttl({ :ok, val }, state, key) do
+    Actions.update(state, key, [{ 2, Util.now() }, { 3, val }])
+  end
+
+end

--- a/test/cachex/actions/touch_test.exs
+++ b/test/cachex/actions/touch_test.exs
@@ -1,0 +1,78 @@
+defmodule Cachex.Actions.TouchTest do
+  use CachexCase
+
+  # This test ensures that we can safely update the touch time of a key without
+  # affecting when the key will be removed. We verify the TTL before and after
+  # to make sure that there is no impact to the TTL, but also ensure that the
+  # touch time on the record has been modified.
+  test "touching a key in the cache" do
+    # create a forwarding hook
+    hook = ForwardHook.create(%{ results: true })
+
+    # create a test cache
+    cache = Helper.create_cache([ hooks: [ hook ] ])
+
+    # pull back the state
+    state = Cachex.State.get(cache)
+
+    # add some keys to the cache
+    { :ok, true } = Cachex.set(cache, 1, 1)
+    { :ok, true } = Cachex.set(cache, 2, 2, ttl: 1000)
+
+    # clear messages
+    Helper.flush()
+
+    # retrieve the raw records
+    { _key1, touched1, ttl1, _value1 } = Cachex.Actions.read(state, 1)
+    { _key2, touched2, ttl2, _value2 } = Cachex.Actions.read(state, 2)
+
+    # the first TTL should be nil
+    assert(ttl1 == nil)
+
+    # the second TTL should be roughly 1000
+    assert_in_delta(ttl2, 995, 6)
+
+    # wait for 50ms
+    :timer.sleep(50)
+
+    # touch the keys
+    touch1 = Cachex.touch(cache, 1)
+    touch2 = Cachex.touch(cache, 2)
+    touch3 = Cachex.touch(cache, 3)
+
+    # the first two writes should succeed
+    assert(touch1 == { :ok, true })
+    assert(touch2 == { :ok, true })
+
+    # the third shouldn't, as it's missing
+    assert(touch3 == { :missing, false })
+
+    # verify the hooks were updated with the message
+    assert_receive({ { :touch, [ 1, [] ] }, ^touch1 })
+    assert_receive({ { :touch, [ 2, [] ] }, ^touch2 })
+    assert_receive({ { :touch, [ 3, [] ] }, ^touch3 })
+
+    # retrieve the raw records again
+    { _key1, touched3, ttl3, _value1 } = Cachex.Actions.read(state, 1)
+    { _key2, touched4, ttl4, _value2 } = Cachex.Actions.read(state, 2)
+
+    # the first ttl should still be nil
+    assert(ttl3 == nil)
+
+    # the first touch time should be roughly 50ms after the first one
+    assert_in_delta(touched3, touched1 + 60, 11)
+
+    # the second ttl should be roughly 50ms lower than the first
+    assert_in_delta(ttl4, ttl2 - 60, 11)
+
+    # the second touch time should also be 50ms after the first one
+    assert_in_delta(touched4, touched2 + 60, 11)
+
+    # for good measure, retrieve the second ttl
+    ttl5 = Cachex.ttl!(cache, 2)
+
+    # it should be roughly 945ms left
+    assert_in_delta(ttl5, 945, 6)
+  end
+
+end


### PR DESCRIPTION
This fixes #73.

Quite a simple solution; we just update the TTL time using the last known TTL coming back from `ttl/2`. If it's missing, we exit. If it's nil, we just update the touch time as-is, and if it's anything else, we touch the time and put the value in as the new TTL. It lives in a transaction for good measure.

You *could* implement all of this using a combination of `ttl/2`, `refresh/2` and `expire/3` instead of rolling it this way (the below shows a working example):

```elixir
case ttl(state, key) do
  { :missing, nil } ->
    { :missing, false }
  { :ok, val } ->
    refresh(state, key)
    val && expire(state, key, val)
    { :ok, true }
end
```

but there's a potential annoying condition between the refresh and expire calls. E.g. what should we do if one of them fails? Probably never going to happen, but regardless.

Anyway, rolling it like this lets it execute a tiny bit quicker.