### PR TITLE
Allow inspect to retrieve raw records

### DIFF
--- a/lib/cachex/actions/inspect.ex
+++ b/lib/cachex/actions/inspect.ex
@@ -13,9 +13,6 @@ defmodule Cachex.Actions.Inspect do
   def execute(%State{ cache: cache }, { :expired, :keys }) do
     { :ok, :ets.select(cache, Util.retrieve_expired_rows(:key)) }
   end
-  def execute(_cache, { :expired, _unknown }) do
-    { :error, "Invalid expiration inspection type provided" }
-  end
 
   # Returns information about the last run of the Janitor process (if there is one).
   def execute(%State{ janitor: ref }, { :janitor, :last }) do
@@ -28,25 +25,30 @@ defmodule Cachex.Actions.Inspect do
 
   # Requests the memory information from a cache, and converts it using the word
   # size of the system, in order to return a number of bytes or as a binary.
-  def execute(%State{ cache: cache }, { :memory, type }) do
+  def execute(%State{ cache: cache }, { :memory, :bytes }) do
     mem_words = :erlang.system_info(:wordsize)
     mem_cache = :ets.info(cache, :memory)
 
-    bytes = mem_words * mem_cache
+    { :ok, mem_words * mem_cache }
+  end
 
-    case type do
-      :bytes ->
-        { :ok, bytes }
-      type when type in [ :binary, :string ] ->
-        { :ok, Util.bytes_to_readable(bytes) }
-      _unknown ->
-        { :error, "Invalid memory inspection type provided" }
+  def execute(%State{ } = state, { :memory, :binary }) do
+    { :ok, bytes } = execute(state, { :memory, :bytes })
+    { :ok, Util.bytes_to_readable(bytes) }
+  end
+
+  def execute(%State{ cache: cache }, { :record, key }) do
+    case :ets.lookup(cache, key) do
+      [] ->
+        { :ok, nil }
+      [rec] ->
+        { :ok, rec }
     end
   end
 
   # Requests the internal state of a cache state.
-  def execute(state, option) when option in [ :state, :worker ] do
-    { :ok, State.get(state.cache) }
+  def execute(%State{ cache: cache }, :state) do
+    { :ok, State.get(cache) }
   end
 
   # If we hit this point, we're not handling the options explicitly, so we just


### PR DESCRIPTION
This fixes #61.

This PR simply introduces the option to pass ` { :record, key }` to an inspect call in order to retrieve the raw record associated with a given key. I also did a little refactoring (but not much) on the memory inspection.