### PR TITLE
Migrate from GenEvent -> GenServer

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -202,9 +202,7 @@ defmodule Cachex do
     hook_spec =
       pre
       |> Enum.concat(post)
-      |> Enum.map(fn(%Hook{ args: args, module: mod, server_args: opts }) ->
-          worker(GenServer, [ mod, args, opts ], [ id: mod ])
-         end)
+      |> Enum.map(&Hook.spec/1)
 
     ttl_workers = if state.ttl_interval do
       [ worker(Janitor, [ state, [ name: state.janitor ] ]) ]

--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -202,8 +202,8 @@ defmodule Cachex do
     hook_spec =
       pre
       |> Enum.concat(post)
-      |> Enum.map(fn(%Hook{ module: mod, server_args: args }) ->
-          worker(GenEvent, [ args ], [ id: mod ])
+      |> Enum.map(fn(%Hook{ args: args, module: mod, server_args: opts }) ->
+          worker(GenServer, [ mod, args, opts ], [ id: mod ])
          end)
 
     ttl_workers = if state.ttl_interval do
@@ -992,18 +992,14 @@ defmodule Cachex do
   # list of Hook structs. Wherever there is a match, the PID of the child is added
   # to the Hook so that a Hook struct can track where it lives.
   defp link_hooks(children, hooks) do
-    Enum.map(hooks, fn(%Hook{ "args": args, "module": mod } = hook) ->
+    Enum.map(hooks, fn(%Hook{ module: mod } = hook) ->
       pid = Enum.find_value(children, fn
         ({ ^mod, pid, _, _ }) -> pid
         (_) -> nil
       end)
 
-      if pid do
-        GenEvent.add_handler(pid, mod, args)
-      end
-
-      %Hook{ hook | "ref": pid }
-     end)
+      %Hook{ hook | ref: pid }
+   end)
   end
 
   # Runs through the initial setup for a cache, parsing a list of options into

--- a/lib/cachex/actions/reset.ex
+++ b/lib/cachex/actions/reset.ex
@@ -85,7 +85,7 @@ defmodule Cachex.Actions.Reset do
   # There is a listener built into the server implementation backing hooks which
   # will handle this automatically, so there's nothing more we need to do.
   defp notify_reset(%Hook{ args: args, ref: ref }) do
-    send(ref, { :notify, { :reset, args } })
+    GenServer.cast(ref, { :cachex_reset, args })
   end
 
 end

--- a/lib/cachex/hook.ex
+++ b/lib/cachex/hook.ex
@@ -11,6 +11,7 @@ defmodule Cachex.Hook do
 
   # add some aliases
   alias Cachex.State
+  alias Supervisor.Spec
 
   # define our opaque type
   @opaque t :: %__MODULE__{ }
@@ -75,7 +76,6 @@ defmodule Cachex.Hook do
   multiple (plugin style) listeners. Initially had the empty clause at the top
   but this way is better (at the very worst it's the same performance).
   """
-  @spec notify(hooks :: [ Hook.t ], action :: { }, results :: { } | nil) :: true
   def notify(hooks, action, result \\ nil)
   def notify([hook|tail], action, result) do
     do_notify(hook, { action, result })
@@ -96,6 +96,13 @@ defmodule Cachex.Hook do
     do: GenServer.call(ref, { :cachex_notify, event }, :infinity)
   defp do_notify(%__MODULE__{ max_timeout: val, ref: ref }, event),
     do: GenServer.call(ref, { :cachex_notify, event, val }, :infinity)
+
+  @doc """
+  Generates a Supervisor specification for a hook.
+  """
+  def spec(%__MODULE__{ module: mod, args: args, server_args: opts }) do
+    Spec.worker(GenServer, [ mod, args, opts ], [ id: mod ])
+  end
 
   @doc """
   Validates a set of Hooks.

--- a/lib/cachex/hook/stats.ex
+++ b/lib/cachex/hook/stats.ex
@@ -38,14 +38,14 @@ defmodule Cachex.Hook.Stats do
   @doc """
   Returns the current stats container to the calling process.
   """
-  def handle_call(:retrieve, stats) do
-    { :ok, stats, stats }
+  def handle_call(:retrieve, _ctx, stats) do
+    { :reply, stats, stats }
   end
 
   @doc """
   Retrieves the current stats container from the Stats process.
   """
   def retrieve(ref),
-  do: GenEvent.call(ref, __MODULE__, :retrieve)
+  do: GenServer.call(ref, :retrieve)
 
 end

--- a/lib/cachex/policy/lrw.ex
+++ b/lib/cachex/policy/lrw.ex
@@ -62,7 +62,7 @@ defmodule Cachex.Policy.LRW do
   of looking up the state. Again an optimization.
   """
   def handle_info({ :provision, { :worker, worker } }, { max_size, trim_bound, _worker }) do
-    { :ok, { max_size, trim_bound, worker } }
+    { :noreply, { max_size, trim_bound, worker } }
   end
 
   # Suggest stepping through this pipeline a function at a time and reading the

--- a/test/cachex/hook_test.exs
+++ b/test/cachex/hook_test.exs
@@ -78,26 +78,31 @@ defmodule Cachex.HookTest do
     hook2 = ForwardHook.create(%{ type: :post })
 
     # create a synchronous hook
-    hook3 = ExecuteHook.create(%{ async: false, max_timeout: 50 })
+    hook3 = ExecuteHook.create(%{ async: false, max_timeout: nil })
+
+    # create a synchronous hook
+    hook4 = ExecuteHook.create(%{ async: false, max_timeout: 50 })
 
     # create a hook without initializing
-    hook4 = ForwardHook.create(%{ })
+    hook5 = ForwardHook.create(%{ })
 
     # initialize caches to initialize the hooks
     cache1 = Helper.create_cache([ hooks: hook1 ])
     cache2 = Helper.create_cache([ hooks: hook2 ])
     cache3 = Helper.create_cache([ hooks: hook3 ])
+    cache4 = Helper.create_cache([ hooks: hook4 ])
 
     # update our hooks from the caches
     [hook1] = Cachex.State.get(cache1).pre_hooks
     [hook2] = Cachex.State.get(cache2).post_hooks
     [hook3] = Cachex.State.get(cache3).post_hooks
+    [hook4] = Cachex.State.get(cache4).post_hooks
 
     # uninitialized hooks shouldn't emit
-    Cachex.Hook.notify([ hook4 ], :hook4, :result)
+    Cachex.Hook.notify([ hook5 ], :hook5, :result)
 
     # ensure nothing is received
-    refute_receive({ :hook4, :result })
+    refute_receive({ :hook5, :result })
 
     # pre hooks only ever get the action
     Cachex.Hook.notify([ hook1 ], :pre_hooks, :result)
@@ -127,7 +132,7 @@ defmodule Cachex.HookTest do
 
     # synchronous hooks can block the notify call up to a limit
     { time2, _value } = :timer.tc(fn ->
-      Cachex.Hook.notify([ hook3 ], fn ->
+      Cachex.Hook.notify([ hook4 ], fn ->
         :timer.sleep(1000)
         :sync_hook
       end)

--- a/test/lib/cachex_case/execute_hook.ex
+++ b/test/lib/cachex_case/execute_hook.ex
@@ -20,6 +20,7 @@ defmodule CachexCase.ExecuteHook do
   # state as it was to start with.
   def handle_notify(fun, _results, proc) do
     handle_info(fun.(), proc)
+    { :ok, proc }
   end
 
   @doc false
@@ -27,7 +28,7 @@ defmodule CachexCase.ExecuteHook do
   # state as it was to start with.
   def handle_info(msg, proc) do
     send(proc, msg)
-    { :ok, proc }
+    { :noreply, proc }
   end
 
 end

--- a/test/lib/cachex_case/forward_hook.ex
+++ b/test/lib/cachex_case/forward_hook.ex
@@ -18,15 +18,17 @@ defmodule CachexCase.ForwardHook do
   @doc false
   # Forwards the received message on to the test process, and simply returns the
   # state as it was to start with.
-  def handle_notify(msg, results, proc),
-  do: handle_info({ msg, results }, proc)
+  def handle_notify(msg, results, proc) do
+    handle_info({ msg, results }, proc)
+    { :ok, proc }
+  end
 
   @doc false
   # Forwards the received message on to the test process, and simply returns the
   # state as it was to start with.
   def handle_info(msg, proc) do
     send(proc, msg)
-    { :ok, proc }
+    { :noreply, proc }
   end
 
 end


### PR DESCRIPTION
The implementation with GenEvent was clunky because Hooks would not shut down when the cache did. Moving to GenServer lets us just put Hooks directly into the same supervision tree, which is neat.

There are a few breaking changes here, but only if someone is using `handle_notify` and `handle_call` from `GenEvent`. Going forward they simply have to migrate to `GenServer` usage and return `{ :noreply, state }` rather than `{ :ok, state }` etc. 

The other thing to note is that timeouts in synchronous hooks are now finally handled on the server side rather than the client (so the server will never hang on a long timeout).

This will fix #71 and #74.