### PR TITLE
Introduce the ability to ignore fallback values

### DIFF
--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -13,53 +13,75 @@ If anything is not covered in here, or there are any issues with anything writte
 
 ## Distribution
 
+We'll start with the big one;
+
 In the v1.x line of Cachex, there was a notion of remote Cachex instances which have been removed in v2.x onwards. This is a design decision due to the limitations of supporting remote instances and the complexities involved, specifically with regards to discovery and eviction policies.
 
-As an alternative to remote Cachex instances, you should now use a remote datastore such as Redis as your master copy and use fallback functions inside Cachex to replicate this data locally. This should support almost all cases for which people required the distributed nature of Cachex. To migrate the behaviour of deletion on remote nodes, simply set a TTL on your data which pulls from Redis and it'll periodically sync automatically. This has the advantage of removing a lot of complexity from Cachex whilst still solving many common use cases.
+In order to migrate away from this, you should now implement a backing datastore such as Redis or Memcached as your master copy and make use of the Cachex fallback behaviour to replicate the data to your local nodes. To handle the removal of data from remote nodes, you should set a TTL on your data and it will periodically and flush automatically. This should support most cases that people were using the distributed nature of Cachex for, but with the main difference that the consistency is now guaranteed and will remain eventually consistent on the local nodes.
 
-If there are cases this doesn't solve, please file issues with a description of what you're trying to do and we can work together to design how to efficiently implement it inside Cachex. I'm not against reintroducing the idea of remote caches if there is an audience for them, as long as they're implemented in such a way that it doesn't limit local caches. There are several ideas in flux around how to make this happen but each needs a lot of thought and review, and so will only be revisited as needed. It may be that this turns into a new library totally based around being an Elixir distributed cache, rather than being forced into Cachex.
+The decision to remove the remote interface does not come lightly; I have spent many weeks trying to conjure something which satisfies the desire of both speed and distribution and the sad truth is that it's quite simply hard to do well. The consistency issues which plague the land of distributed data are just not possible to handle whilst keeping Cachex as fast as it is (and at the end of the day, a cache is supposed to be fast). The final tipping point was the concept of building LRU style caches in a remote context; it's simply not possible to guarantee the consistency of your data without a huge performance hit (we're talking upwards of 1000x slower) due to Cachex operating in the realm of a microsecond.
+
+Do not despair though; if you were totally set on using a native Elixir/Erlang datastore witout having to have something separate such as Redis, I'm planning on writing a separate library which is dedicated more to handling the distributed nature as opposed to the feature set that Cachex offers. At the end of the day, I see caching as a different use case to remote data replication - I believe remote Cachex was closer to a distributed state table, rather than a local mirror of data.
+
+In addition, you can obviously keep on using Cachex `v1.x` as long as you need - it's still on Hex.pm and has a tag on the repo. I can't promise anything new will be added to that codebase, but for what it's worth I do intend to answer any issues reporting bugs on that branch, so file issues as you see fit - just make sure to flag that you're talking about `v1.x`.
 
 ## Hook Interface
 
-There have been a couple of tweaks to the interface behind hooks to make them more convenient to work with:
+Hooks have undergone a bit of tweaking in v2 simply because they were built back when I wasn't fully familiar with the `Gen*` models. The changes are easy to adopt and shouldn't take you much more than a few minutes to modify your codebase:
 
 ### Callbacks
 
-The biggest change made to Hooks is that we have migrated from `GenEvent` to `GenServer`. This means that if you're implementing Hooks, you need to respect the return formats of the `GenServer` module rather than that of `GenEvent`. This only affects callbacks, such as `handle_call/2` and `handle_info/2`, so if you haven't used them you're going to be fine.
+The biggest change made to Hooks is that we have migrated from `GenEvent` to `GenServer`. This means that if you're implementing Hooks, you need to respect the return formats of the `GenServer` module rather than that of `GenEvent`. This only affects the `Gen*` callbacks, such as `handle_call/2` and `handle_info/2`, so if you haven't used them you're going to be fine in this respect.
 
 The `handle_call/2` callback should become `handle_call/3`, with a new second parameter which is simply the context of the call (and you likely won't ever use). In addition, the return type now becomes `{ :reply, reply, new_state }` instead of `{ :ok, reply, new_state }` - so just a few characters to tweak there. The same applies for `handle_info/2` in that you need to change `{ :ok, new_state }` to `{ :noreply, new_state }`.
 
-The reason the change was made is that your hooks now live in the Supervision tree alongside the cache, rather than under a `GenEvent` process. This allows shutdown to run more smoothly, and just generally lays out the tree much better. In addition, you now gain access to `handle_cast/2` from the `GenServer` module and it's a much more familiar interface to deal with as opposed to `GenEvent`, which is falling out of use.
+The reason the change was made is that your hooks now live in the Supervision tree alongside the cache, rather than under a `GenEvent` process. This allows shutdown to run more smoothly, and just generally lays out the tree much better. In addition, you now gain access to `handle_cast/2` from the `GenServer` module and it's a much more familiar interface to deal with as opposed to `GenEvent`, which is falling more and more out of use by most Elixir developers.
 
 ### Defaults
 
-Firstly, Hooks will default to being of `type: :post`. This is because post hooks are the more common use case, and it was very easy to become confused when trying to deal with results and receiving nothing (because of the default to `:pre`). I feel that defaulting to `:post` going forward is more user-friendly. This is a very easy thing to update, and you should make sure to always specify `:type` on your Hooks in future to avoid relying on this default.
+The only big change here is that the `:type` option of a hook previously defaulted to being a `:pre` hook. This has now changed to default to a `:post` hook.
+
+The reasoning behind this is that post hooks are a more common use case - you typically don't want to react to the desire to do something, you want to react to something happening. It was also quite easy to become confused when trying to play with results and receiving nothing. This sucked, because it meant that an entirely different function would be called because of the arity changes when requesting results.
+
+This is a very easy thing to update, and you can always make sure to specify `:type` on your Hooks in future to avoid relying on this default (I imagine most people have done that anyway, so good job!).
 
 ### Message Format
 
-There has been a change in the message format used to talk to Hooks. Previously this was a Tuple of the action and arguments, e.g. `{ :get, "key", [] }`. Going forward, this will always be a two-element Tuple, with the action and a list of arguments, e.g. `{ :get, [ "key", [] ] }`. This change makes it easier to pattern match only on the action (something very common in hooks) and avoids arbitrarily long Tuples (which is almost always the wrong thing to do).
+After talking to a couple of people on the Slack channels, it dawned on me that the current Hook message implementation is quite bad - in the sense that there's a performance hit, and it's awkward to use. The currently pattern behaves as a Tuple of action arguments, so `Cachex.get(:cache, "key", opts)` would forward as `{ :get, "key", opts }`.
+
+At a glance it looks like there's nothing wrong with this, but it makes pattern matching difficult and there's clearly a Tuple construction to create that message. Going forward, it is now guaranteed that a message will be a two-element Tuple, with the action as a tag and a list of arguments - so the above would become `{ :get, [ "key", opts ]}`.
+
+This change makes it super easy to pattern match on the action name (for example, the new LRW hook only activates on write actions), and gives you the guarantee that your message will always be the same form as opposed to having arbitrarily long Tuples (which is pretty much always the wrong thing to do).
 
 ### Results
 
-Results are now always provided in the call to a Hook, in order to keep the logic behind hook notifications simply and remove some messy conditions there. If you have a `:pre` hook, it will simply receive `nil` as the results.
+The decision has been made to always provide results to a post hook, in order to keep the backing logic simple and remove some conditions. It's cheap to forward the results, so there's no real overhead to doing this. Previously the intent was to separate the concerns, but it just led to confusing message handling due to having to use both `handle_notify/2` and `handle_notify/3`. Going forward, you will only ever use `handle_notify/3` (because `handle_notify/2` has been removed). This means that results are also given to your `:pre` hooks, but they're **always** `nil` inside a pre hook and can just be ignored. You should note that if you were previously using `results: true` in your Hook, you shouldn't need to change anything. Examples below:
 
-The above means that the `:results` option in the Hook struct has been removed, and that `handle_notify/2` is no longer used. These two things are fairly easy to adapt to. For the `:results` option, simply drop it from any Hook definitions that you may have and you should be good to go. Adapting from `handle_notify/2` to `handle_notify/3` is also easy enough, it's as straightforward as adding a new parameter to the function as shown below. If you previously had `results: true`, then no change is needed.
-
-```
+```elixir
+# old format
 def handle_notify(msg, state)
+
+# new format
 def handle_notify(msg, result, state)
 ```
 
+Obviously because this is always enabled there's no need for an option, and so the `:results` option has been removed from the Hook struct - so you need to drop it from any Hook definitions you have.
+
 ## Options
 
-There are a few option changes on a cache interface when starting one up in v2. The first is that passing the `:name` option in the list of options has been totally removed, rather than just being deprecated. You must now provide the cache name as the first parameter in `start_link/3`. Other changes include:
+There are a few minor tweaks to the options when starting a cache:
 
-- `ttl_interval: false` should be replaced with `ttl_interval: -1`, as `false` is no longer recognised.
-- `:default_fallback` has been renamed to `:fallback`, this should be used going forward.
+1. The first change is that the previously deprecated `:name` option has been removed. You should now use `start_link/3` or `start/3` and pass the cache name as the first argument. This is to remove some complexity with name validation (in that it's easier to pick out now without parsing options first).
+
+2. The `:ttl_interval` could previously be disabled if set to `false`. This has changed as it's required to be numeric at this point for other reasons, so going forward you should pass `-1` if you wish to disable the interval.
+
+3. This is a small change, but it bothered me often enough to make it. The `:default_fallback` option has been simply renamed to `:fallback`, as it's much easier to write and it's more consistent with the same option inside a `get/3` call (which is also `:fallback`). Long gone are the days in which you pass `:fallback` to a cache only to have it ignored.
 
 ## Transactions
 
-There are a number of changes in Transactions due to the removal of Mnesia which occurred in Cachex v2. The first is that you must now define the keys you wish to lock in your transaction call as the second parameter. This is part of a new locking mechanism which optimizes the cache to run faster by forcing you to specify your locks (previously there was a table lock). This has the advantage of speeding up transactions by roughly 5x. This is fairly easy to adopt, you just pass any keys you write to in your transactions in a list as the second parameter:
+As of Cachex v2.x, Mnesia has been removed in favour of direct ETS interation. As a result of this, there are several changes in the way transactions work.
+
+The first change is down to optimizations of key locking, and requires that you now pass a list of keys to lock as your second parameter to a `transaction/3` call. This is part of the new locking implementation which allows for several optimizations by being explicit with your locks. This optimization provides roughly a 5x speedup, so it's much more efficient than previously. This is pretty easy to adopt:
 
 ```elixir
 Cachex.transaction(:my_cache, [ "key1" ], fn(state) ->
@@ -69,4 +91,8 @@ Cachex.transaction(:my_cache, [ "key1" ], fn(state) ->
 end)
 ```
 
-If you don't pass a key you write, it will not be protected by the locking Cachex works against and may be overwritten in the middle of a transaction. You should note that there is no longer an `abort/1` function for use inside a transaction. This is because your writes happen immediately and without a checkpoint, so there's no way to roll them back. You should therefore handle aborts in your logic rather than just bailing out - this is clearly possible as you have a consistent view of all the keys you need before any changes occur.
+If you write to a key which has not been defined in the `keys` parameter, please be aware that it will not be locked and may be written by other processes during your transaction. It also goes without saying that nested transactions should only operate on a subset of keys in an outer transaction.
+
+The second change is that there is no longer support for `abort/1` from within a transaction, meaning that all writes happen immediately even within your transaction. I don't believe this should be difficult to adopt, as I would imagine that `abort/1` is only used infrequently. It should not be hard to simply rework your transaction flow to exit as needed.
+
+The final thing to note here is that transactions are all handled by a lock process, which means you should try to avoid causing a bottleneck in your transactions. For example, if you need to check list membership or create new Tuples, try do this outside your transaction first and simply pass it through - this will lessen the time spent in the transaction process and improve performance with transactions. This isn't always possible, but try to optimize like this when applicable.

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ A very common use case (and one of the reasons I built Cachex) is the desire to 
 
 Let's look at an example;
 
-Assume you have a backing Redis cache with a fairly large amount of keys, and you wish to cache it locally to avoid the network calls (let's say you're doing it thousands of times a second). Cachex can do this easily be providing a **fallback** action to take when a key is missing. This is configured during cache initialization using the `default_fallback` option, as below:
+Assume you have a backing Redis cache with a fairly large amount of keys, and you wish to cache it locally to avoid the network calls (let's say you're doing it thousands of times a second). Cachex can do this easily be providing a **fallback** action to take when a key is missing. This is configured during cache initialization using the `fallback` option, as below:
 
 ```elixir
 # initialize the cache instance

--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -92,8 +92,14 @@ defmodule Cachex do
       This function is called with a key which has no value, in order to allow loading
       from a different location.
 
+      You should tag the return value inside a `:commit` Tuple, to signal that you
+      wish to commit the changes to the cache. If you *don't* want to commit the
+      changes (for example if something goes wrong), you can use `{ :ignore, val }`
+      to only return the value and not persist it. If you don't specify either of
+      these flags, it will be assumed you are committing your changes.
+
           iex> Cachex.start_link(:my_cache, [ fallback: fn(key) ->
-          ...>   generate_value(key)
+          ...>   { :commit, generate_value(key) }
           ...> end])
 
     - **fallback_args**

--- a/lib/cachex/actions/get.ex
+++ b/lib/cachex/actions/get.ex
@@ -47,14 +47,17 @@ defmodule Cachex.Actions.Get do
   # value, we've missing the cache and haven't been able to load anything so we
   # just return nil and stop. If we have received a fallback, then we make sure
   # to set the value inside the cache so that it can be hit first try next time.
-  defp handle_fallback({ :ok, nil }, _state, _key, _opts) do
-    { :missing, nil }
-  end
-  defp handle_fallback({ :loaded, value } = res, state, key, opts) do
+  defp handle_fallback({ :default, val }, _state, _key, _opts),
+    do: { :missing, val }
+  defp handle_fallback({ :ignore, val }, _state, _key, _opts),
+    do: { :loaded, val }
+  defp handle_fallback({ :commit, val }, state, key, opts) do
     note_opt = Enum.find(opts, [], &find_notify/1)
     set_opts = List.wrap(note_opt)
-    Set.execute(state, key, value, set_opts)
-    res
+
+    Set.execute(state, key, val, set_opts)
+
+    { :loaded, val }
   end
 
   # Simply returns true only if the option key is `:notify`.

--- a/lib/cachex/actions/stats.ex
+++ b/lib/cachex/actions/stats.ex
@@ -69,9 +69,8 @@ defmodule Cachex.Actions.Stats do
     meta   = Map.get(stats,   :meta, %{ })
     global = Map.get(stats, :global, %{ })
 
-    load_count = Map.get(global, :loadCount, 0)
     hits_count = Map.get(global,  :hitCount, 0)
-    miss_count = Map.get(global, :missCount, 0) + load_count
+    miss_count = Map.get(global, :missCount, 0)
 
     req_rates = case hits_count + miss_count do
       0 -> %{ }

--- a/lib/cachex/lock_manager.ex
+++ b/lib/cachex/lock_manager.ex
@@ -31,8 +31,9 @@ defmodule Cachex.LockManager do
   Sets whether this process is inside a transactional context.
   """
   def set_transaction(transactional) do
-    Process.put(:transactional, !!transactional)
-    !!transactional
+    bool = !!transactional
+    Process.put(:transactional, bool)
+    bool
   end
 
   @doc """

--- a/lib/cachex/util.ex
+++ b/lib/cachex/util.ex
@@ -66,15 +66,15 @@ defmodule Cachex.Util do
     cond do
       # valid provided fallback
       is_function(fb_fun, fb_len) ->
-        { :loaded, apply(fb_fun, fb_args) }
+        fb_fun |> apply(fb_args) |> normalize_commit
 
       # valid default fallback
       is_function(fb_def, fb_len) ->
-        { :loaded, apply(fb_def, fb_args) }
+        fb_def |> apply(fb_args) |> normalize_commit
 
       # no fallback
       true ->
-        { :ok, default }
+        { :default, default }
     end
   end
 
@@ -127,6 +127,14 @@ defmodule Cachex.Util do
       n -> elem(tuple, n - 1)
     end
   end
+
+  @doc """
+  Normalizes a commit result to determine whether we're going to signal to
+  commit the changes to the cache, or simply ignore the changes and return.
+  """
+  def normalize_commit({ :commit, _val } = val), do: val
+  def normalize_commit({ :ignore, _val } = val), do: val
+  def normalize_commit(val), do: { :commit, val }
 
   @doc """
   Consistency wrapper around current time in millis.

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,7 @@
   "deppie": {:hex, :deppie, "1.0.0", "ec1207cdadf7c81aea171cb8acc68fc0eb1a8f6015ad785e6b5001dbb2a7d7ea", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
   "eternal": {:hex, :eternal, "1.1.3", "e9193326d9f8475bdc75a3e8cc83aa317449c5aeb41b315d6e1b67068075f028", [:mix], [{:deppie, "~> 1.0", [hex: :deppie, optional: false]}]},
-  "ex_doc": {:hex, :ex_doc, "0.13.1", "658dbfc8cc5b0fac192f0f3254efe66ee6294200804a291549e0aeb052053bba", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "ex_doc": {:hex, :ex_doc, "0.13.2", "1059a588d2ad3ffab25a0b85c58abf08e437d3e7a9124ac255e1d15cec68ab79", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "excoveralls": {:hex, :excoveralls, "0.5.6", "35a903f6f78619ee7f951448dddfbef094b3a0d8581657afaf66465bc930468e", [:mix], [{:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}]},
   "exjsx": {:hex, :exjsx, "3.2.0", "7136cc739ace295fc74c378f33699e5145bead4fdc1b4799822d0287489136fb", [:mix], [{:jsx, "~> 2.6.2", [hex: :jsx, optional: false]}]},
   "exprintf": {:hex, :exprintf, "0.1.6", "b5b0a38bf78a357dbc61cdf7364fea004af6fdf5214be44021eb2ea7edf61f6e", [:mix], []},

--- a/test/cachex/actions/get_test.exs
+++ b/test/cachex/actions/get_test.exs
@@ -32,13 +32,15 @@ defmodule Cachex.Actions.GetTest do
     result3 = Cachex.get(cache1, 3)
 
     # define the fallback options
-    fb_opts = [ fallback: fn(key, val) ->
-      key <> "_" <> val
-    end ]
+    fb_opts1 = [ fallback: &(&1 <> "_" <> &2) ]
+    fb_opts2 = [ fallback: &({ :commit, &1 <> "_" <> &2 }) ]
+    fb_opts3 = [ fallback: &({ :ignore, &1 <> "_" <> &2 }) ]
 
     # take keys with a fallback
     result4 = Cachex.get(cache2, "key1")
-    result5 = Cachex.get(cache2, "key2", fb_opts)
+    result5 = Cachex.get(cache2, "key2", fb_opts1)
+    result6 = Cachex.get(cache2, "key3", fb_opts2)
+    result7 = Cachex.get(cache2, "key4", fb_opts3)
 
     # verify the first key is retrieved
     assert(result1 == { :ok, 1 })
@@ -50,15 +52,19 @@ defmodule Cachex.Actions.GetTest do
     # verify the fourth key uses the default fallback
     assert(result4 == { :loaded, "lav_1yek" })
 
-    # verify the fifth uses the custom fallback
+    # verify the fifth, sixth and seventh uses the custom fallback
     assert(result5 == { :loaded, "key2_val" })
+    assert(result6 == { :loaded, "key3_val" })
+    assert(result7 == { :loaded, "key4_val" })
 
     # assert we receive valid notifications
     assert_receive({ { :get, [ 1, [ ] ] }, ^result1 })
     assert_receive({ { :get, [ 2, [ ] ] }, ^result2 })
     assert_receive({ { :get, [ 3, [ ] ] }, ^result3 })
     assert_receive({ { :get, [ "key1", [ ] ] }, ^result4 })
-    assert_receive({ { :get, [ "key2", ^fb_opts ] }, ^result5 })
+    assert_receive({ { :get, [ "key2", ^fb_opts1 ] }, ^result5 })
+    assert_receive({ { :get, [ "key3", ^fb_opts2 ] }, ^result6 })
+    assert_receive({ { :get, [ "key4", ^fb_opts3 ] }, ^result7 })
 
     # check we received valid purge actions for the TTL
     assert_receive({ { :purge, [[]] }, { :ok, 1 } })
@@ -72,10 +78,18 @@ defmodule Cachex.Actions.GetTest do
     # retrieve the loaded keys
     value1 = Cachex.get(cache2, "key1")
     value2 = Cachex.get(cache2, "key2")
+    value3 = Cachex.get(cache2, "key3")
 
     # both should now exist
     assert(value1 == { :ok, "lav_1yek" })
     assert(value2 == { :ok, "key2_val" })
+    assert(value3 == { :ok, "key3_val" })
+
+    # verify the :ignore response is not commited
+    exists2 = Cachex.exists?(cache1, "key4")
+
+    # it shouldn't exist
+    assert(exists2 == { :ok, false })
   end
 
 end

--- a/test/cachex/actions/stats_test.exs
+++ b/test/cachex/actions/stats_test.exs
@@ -90,6 +90,7 @@ defmodule Cachex.Actions.StatsTest do
     cache1 = Helper.create_cache([ record_stats: true ])
     cache2 = Helper.create_cache([ record_stats: true ])
     cache3 = Helper.create_cache([ record_stats: true ])
+    cache4 = Helper.create_cache([ record_stats: true ])
 
     # retrieve stats with no rates
     stats1 = Cachex.stats!(cache1)
@@ -112,15 +113,22 @@ defmodule Cachex.Actions.StatsTest do
     { :ok,    1 } = Cachex.get(cache3, 1)
     { :missing, nil } = Cachex.get(cache3, 2)
 
+    # set cache4 to have some loads
+    { :loaded, 1 } = Cachex.get(cache4, 1, fallback: &(&1))
+
     # retrieve all cache rates
     stats2 = Cachex.stats!(cache1)
     stats3 = Cachex.stats!(cache2)
     stats4 = Cachex.stats!(cache3)
+    stats5 = Cachex.stats!(cache4)
 
     # remove the creationDate
     stats2 = Map.delete(stats2, :creationDate)
     stats3 = Map.delete(stats3, :creationDate)
     stats4 = Map.delete(stats4, :creationDate)
+    stats5 = Map.delete(stats5, :creationDate)
+
+    IO.inspect(stats5)
 
     # verify a 100% miss rate for cache1
     assert(stats2 == %{
@@ -151,6 +159,18 @@ defmodule Cachex.Actions.StatsTest do
       missRate: 50.0,
       opCount: 3,
       requestCount: 2,
+      setCount: 1
+    })
+
+    # verify a load count for cache4
+    assert(stats5 == %{
+      hitCount: 0,
+      hitRate: 0.0,
+      loadCount: 1,
+      missCount: 1,
+      missRate: 100.0,
+      opCount: 2,
+      requestCount: 1,
       setCount: 1
     })
   end


### PR DESCRIPTION
This fixes #82.

This PR introduces the concept of tagged fallback values, in order to better determine when a user wishes to commit the value to the cache. It's possible that something unexpected happens in a fallback (network timeout, etc), and the user may wish to skip persisting the value. In this scenario the user can simply use `{ :ignore, value }` to return `value` back from the call, but without committing `value` into the cache. This is a great benefit as errors can be returned without being committed.

To commit your changes, you simply need to return `{ :commit, value }` and it will be written. If neither of these flags are provided, we'll assume that you're committing (this is for backwards compatibility).

This also fixes a quick bug in the stats calculations which was doubling up counts in the case of value loading. 