### PR TITLE
Restructure the syntax required for providing fallbacks

### DIFF
--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -3,6 +3,7 @@
 If anything is not covered in here, or there are any issues with anything written in here, please file an issue and I'll get it taken care of.
 
 - [Distribution](#distribution)
+- [Fallbacks](#fallbacks)
 - [Hook Interface](#hook-interface)
   - [Callbacks](#callbacks)
   - [Defaults](#defaults)
@@ -24,6 +25,33 @@ The decision to remove the remote interface does not come lightly; I have spent 
 Do not despair though; if you were totally set on using a native Elixir/Erlang datastore witout having to have something separate such as Redis, I'm planning on writing a separate library which is dedicated more to handling the distributed nature as opposed to the feature set that Cachex offers. At the end of the day, I see caching as a different use case to remote data replication - I believe remote Cachex was closer to a distributed state table, rather than a local mirror of data.
 
 In addition, you can obviously keep on using Cachex `v1.x` as long as you need - it's still on Hex.pm and has a tag on the repo. I can't promise anything new will be added to that codebase, but for what it's worth I do intend to answer any issues reporting bugs on that branch, so file issues as you see fit - just make sure to flag that you're talking about `v1.x`.
+
+## Fallbacks
+
+The options and interface for fallback functions have changed a little bit in order to optimize their efficiency and just remove some bloat from the fallback flow.
+
+In the v1.x branch of Cachex, there were two cache options related to fallbacks; `:default_fallback` and `:fallback_args`. This was a little clumsy looking, and so this has been unified in v2.x to only be a simple `:fallback` option. This can either be a function, or list of fallback options. Below are some examples:
+
+```elixir
+# fallback with no state
+[ fallback: fn(key) -> do_fallback(key) end ]
+[ fallback: [ action: fn(key) -> do_fallback(key) end ] ]
+
+# fallback with a state
+[
+  fallback: [
+    state: db_client,
+    action: fn(key, client) ->
+      retrieve_from_db(client, key)
+    end
+  ]
+]
+
+# provide a state but no default fallback
+[ fallback: [ state: db_client ] ]
+```
+
+It should be noted that the `state` is passed in as a second argument in the case that the `state` provided is not `nil`. This is another change to previously where you would provide a list and have arbitrarily long arguments. This change was made as it's a more efficient way of calling a fallback and lessens the overhead involved.
 
 ## Hook Interface
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ end)
 
 The above is a multi-layered cache which only hits the database **at most** every 5 minutes, and hits local memory in the meantime (retrieving the exact same data as was returned from your database). This allows you to easily lower the pressure on your backing systems as the context of your call requires - for example in the use case above, we can totally ignore the key argument as the function is only ever invoked on that call.
 
-Also note that this example demonstrates how you can provide state to your fallback functions by providing a Keyword List against the `:fallback` option. This list can contain the `:state` and `:action` keys to further customize how fallbacks work. The state is provided as a second argument to the action in the case it is provided and is not set to `nil`.
+Also note that this example demonstrates how you can provide state to your fallback functions by providing a Keyword List against the `:fallback` option. This list can contain the `:state` and `:action` keys to further customize how fallbacks work. The state is provided as a second argument to the action in the case it is not set to `nil`.
 
 As demonstrated in the [Common Fallbacks](#common-fallbacks) section above, providing a function instead of a List is internally converted to `[ action: &RedisClient.get/1 ]`. It is simply shorthand in case you do not wish to provide a state.
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,7 @@ Caches can accept a list of options during initialization, which determine vario
 |     ets_opts     |   list of options  |               A list of options to give to the ETS table.               |
 |    default_ttl   |     milliseconds   | A default expiration time for a key when being placed inside the cache. |
 |    disable_ode   |  `true` or `false` | Whether or not to disable on-demand expirations when reading back keys. |
-|     fallback     |       function     |   A function accepting a key which is used for multi-layered caching.   |
-|   fallback_args  |  list of arguments |  A list of arguments to pass alongside the key to a fallback function.  |
+|     fallback     |  Function or List  |   A function accepting a key which is used for multi-layered caching.   |
 |       hooks      |    list of Hooks   |    A list of execution hooks (see below) to listen on cache actions.    |
 |       limit      |  a Limit constuct  |     An integer or Limit struct to define the bounds of this cache.      |
 |   record_stats   |  `true` or `false` |            Whether to track statistics for this cache or not.           |
@@ -207,7 +206,7 @@ Using another example, let's assume that you need to read information from a dat
 { :ok, db } = initialize_database_client()
 
 # initialize the cache instance
-{ :ok, pid } = Cachex.start_link(:info_cache, [ default_ttl: :timer.minutes(5), fallback_args: [db] ])
+{ :ok, pid } = Cachex.start_link(:info_cache, [ default_ttl: :timer.minutes(5), fallback: [ state: db ] ])
 
 # status will equal :loaded if the database was hit, otherwise :ok when successful
 { status, information } = Cachex.get(:info_cache, "/api/v1/packages", fallback: fn(key, db) ->
@@ -215,7 +214,11 @@ Using another example, let's assume that you need to read information from a dat
 end)
 ```
 
-The above is a multi-layered cache which only hits the database **at most** every 5 minutes, and hits local memory in the meantime (retrieving the exact same data as was returned from your database). This allows you to easily lower the pressure on your backing systems as the context of your call requires - for example in the use case above, we can totally ignore the key argument as the function is only ever invoked on that call. Also note that this example demonstrates how you can bind arguments to your fallback functions using the `fallback_args` option.
+The above is a multi-layered cache which only hits the database **at most** every 5 minutes, and hits local memory in the meantime (retrieving the exact same data as was returned from your database). This allows you to easily lower the pressure on your backing systems as the context of your call requires - for example in the use case above, we can totally ignore the key argument as the function is only ever invoked on that call.
+
+Also note that this example demonstrates how you can provide state to your fallback functions by providing a Keyword List against the `:fallback` option. This list can contain the `:state` and `:action` keys to further customize how fallbacks work. The state is provided as a second argument to the action in the case it is provided and is not set to `nil`.
+
+As demonstrated in the [Common Fallbacks](#common-fallbacks) section above, providing a function instead of a List is internally converted to `[ action: &RedisClient.get/1 ]`. It is simply shorthand in case you do not wish to provide a state.
 
 ## Execution Hooks
 
@@ -234,7 +237,6 @@ Cachex uses the typical `GenServer` pattern, and as such you get most of the typ
 #### Definition
 
 Hooks are quite simply a small abstraction above the existing `GenServer` which ships with Elixir. Cachex tweaks a couple of minor things related to synchronous execution and argument format, but nothing too special. Below is an example of a very basic hook implementation:
-
 
 ```elixir
 defmodule MyProject.MyHook do
@@ -327,7 +329,7 @@ These fields translate to the following:
 |max_timeout| no. of milliseconds| A maximum time to wait for your synchronous hook to complete.  |
 |   module  | a module definition| A module containing your which implements the Hook interface.  |
 |  provide  |    list of atoms   |      A list of post-startup values to provide to your hook.    |
-|server_args|        any         |           Arguments to pass to the GenEvent server.            |
+|server_args|        any         |              Arguments to pass to the GenServer.               |
 |   type    | `:pre` or `:post`  |   Whether this hook should execute before or after the action. |
 
 **Notes**

--- a/coveralls.json
+++ b/coveralls.json
@@ -3,7 +3,6 @@
     "defmodule",
     "defrecord",
     "defimpl",
-    "defexception",
     "defprotocol",
     "defstruct",
     "defdelegate",

--- a/lib/cachex/fallback.ex
+++ b/lib/cachex/fallback.ex
@@ -1,0 +1,30 @@
+defmodule Cachex.Fallback do
+  @moduledoc false
+  # This module just contains the struct definitions of a `Cachex.Fallback` model,
+  # in order to provide an easy way to move fallback options around without relying
+  # on Tuples or Keyword Lists.
+
+  # internal structure
+  defstruct [
+    state: nil,   # the state to provide to a fallback
+    action: nil   # the action a fallback should take
+  ]
+
+  # our opaque type
+  @opaque t :: %__MODULE__{ }
+
+  @doc """
+  Parses an input into a Fallback struct.
+
+  We expect a list of options and use them to derive the Fallback. If anything
+  other than options are provided, we just return a default structure.
+  """
+  def parse(options) when is_list(options),
+    do: %__MODULE__{
+      state:  Keyword.get(options, :state),
+      action: Cachex.Util.get_opt(options, :action, &is_function/1)
+    }
+  def parse(_options),
+    do: %__MODULE__{ }
+
+end

--- a/lib/cachex/state.ex
+++ b/lib/cachex/state.ex
@@ -9,27 +9,28 @@ defmodule Cachex.State do
   # and should only be accessed via this module. The interface is deliberately
   # small in order to reduce potential complexity.
 
-  # internal state struct
-  defstruct cache: nil,             # the name of the cache
-            disable_ode: false,     # whether we disable on-demand expiration
-            ets_opts: nil,          # any options to give to ETS
-            default_ttl: nil,       # any default ttl values to use
-            fallback: nil,          # the default fallback implementation
-            fallback_args: nil,     # arguments to pass to a cache loader
-            janitor: nil,           # the name of the janitor attached (if any)
-            limit: nil,             # any limit to apply to the cache
-            manager: nil,           # the name of the manager attached
-            pre_hooks: nil,         # any pre hooks to attach
-            post_hooks: nil,        # any post hooks to attach
-            transactions: nil,      # whether to enable transactions
-            ttl_interval: nil       # the ttl check interval
-
   # grab constants
   use Cachex.Constants
 
   # add any aliases
+  alias Cachex.Fallback
   alias Cachex.Hook
+  alias Cachex.Limit
   alias Supervisor.Spec
+
+  # internal state struct
+  defstruct cache: nil,             # the name of the cache
+            disable_ode: false,     # whether we disable on-demand expiration
+            ets_opts: [],           # any options to give to ETS
+            default_ttl: nil,       # any default ttl values to use
+            fallback: %Fallback{},  # the default fallback implementation
+            janitor: nil,           # the name of the janitor attached (if any)
+            limit: %Limit{},        # any limit to apply to the cache
+            manager: nil,           # the name of the manager attached
+            pre_hooks: [],          # any pre hooks to attach
+            post_hooks: [],         # any post hooks to attach
+            transactions: false,    # whether to enable transactions
+            ttl_interval: nil       # the ttl check interval
 
   # our opaque type
   @opaque t :: %__MODULE__{ }

--- a/lib/cachex/stats.ex
+++ b/lib/cachex/stats.ex
@@ -13,7 +13,7 @@ defmodule Cachex.Stats do
   global operation count, but all other changes are action-specific.
   """
   @spec register(action :: { }, result :: { }, stats :: %{ }) :: %{ }
-  def register(action, result, stats \\ %{ }) do
+  def register(action, result, stats) do
     action
     |> process_action(result)
     |> Enum.reduce(stats, &increment/2)

--- a/mix.exs
+++ b/mix.exs
@@ -67,7 +67,7 @@ defmodule Cachex.Mixfile do
       { :benchfella,   "~> 0.3",  optional: true, only: [ :dev, :test ] },
       { :bmark,        "~> 1.0",  optional: true, only: [ :dev, :test ] },
       { :credo,        "~> 0.4",  optional: true, only: [ :dev, :test ] },
-      { :ex_doc,       "~> 0.13", optional: true, only: [ :dev, :test ] },
+      { :ex_doc,       "~> 0.14", optional: true, only: [ :dev, :test ] },
       { :excoveralls,  "~> 0.5",  optional: true, only: [ :dev, :test ] },
       { :exprof,       "~> 0.2",  optional: true, only: [ :dev, :test ] }
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,7 @@
   "deppie": {:hex, :deppie, "1.0.0", "ec1207cdadf7c81aea171cb8acc68fc0eb1a8f6015ad785e6b5001dbb2a7d7ea", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
   "eternal": {:hex, :eternal, "1.1.3", "e9193326d9f8475bdc75a3e8cc83aa317449c5aeb41b315d6e1b67068075f028", [:mix], [{:deppie, "~> 1.0", [hex: :deppie, optional: false]}]},
-  "ex_doc": {:hex, :ex_doc, "0.13.2", "1059a588d2ad3ffab25a0b85c58abf08e437d3e7a9124ac255e1d15cec68ab79", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "ex_doc": {:hex, :ex_doc, "0.14.1", "bfed8d4e93c755e2b150be925ad2cfa6af7c3bfcacc3b609f45f6048c9d623d6", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "excoveralls": {:hex, :excoveralls, "0.5.6", "35a903f6f78619ee7f951448dddfbef094b3a0d8581657afaf66465bc930468e", [:mix], [{:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}]},
   "exjsx": {:hex, :exjsx, "3.2.0", "7136cc739ace295fc74c378f33699e5145bead4fdc1b4799822d0287489136fb", [:mix], [{:jsx, "~> 2.6.2", [hex: :jsx, optional: false]}]},
   "exprintf": {:hex, :exprintf, "0.1.6", "b5b0a38bf78a357dbc61cdf7364fea004af6fdf5214be44021eb2ea7edf61f6e", [:mix], []},

--- a/test/cachex/actions/get_test.exs
+++ b/test/cachex/actions/get_test.exs
@@ -10,9 +10,13 @@ defmodule Cachex.Actions.GetTest do
 
     # create a test cache
     cache1 = Helper.create_cache([ hooks: [ hook ] ])
-    cache2 = Helper.create_cache([ hooks: [ hook ], fallback_args: [ "val" ], fallback: fn(key, val) ->
-      String.reverse("#{key}_#{val}")
-    end ])
+    cache2 = Helper.create_cache([
+      hooks: [ hook ],
+      fallback: [
+        state: "val",
+        action: &String.reverse("#{&1}_#{&2}")
+      ]
+    ])
 
     # set some keys in the cache
     { :ok, true } = Cachex.set(cache1, 1, 1)

--- a/test/cachex/actions/stats_test.exs
+++ b/test/cachex/actions/stats_test.exs
@@ -128,8 +128,6 @@ defmodule Cachex.Actions.StatsTest do
     stats4 = Map.delete(stats4, :creationDate)
     stats5 = Map.delete(stats5, :creationDate)
 
-    IO.inspect(stats5)
-
     # verify a 100% miss rate for cache1
     assert(stats2 == %{
       hitCount: 0,

--- a/test/cachex/fallback_test.exs
+++ b/test/cachex/fallback_test.exs
@@ -1,0 +1,40 @@
+defmodule Cachex.FallbackTest do
+  use CachexCase
+
+  # This test verifies the ability to parse a Keyword List into a Cachex Fallback.
+  # This is used inside `Cachex.Options` when parsing the fallback options just
+  # to add a little more structure rather than a Keyword List being stored. We
+  # just verify various option combinations in this test to cover most cases.
+  test "parsing values into a Fallback" do
+    # define our falbacks as options
+    fallback1 = []
+    fallback2 = [ action: &String.reverse/1 ]
+    fallback3 = [ action: &String.reverse/1, state: {} ]
+    fallback4 = [ state: {} ]
+    fallback5 = { }
+
+    # convert all options to fallbacks
+    result1 = Cachex.Fallback.parse(fallback1)
+    result2 = Cachex.Fallback.parse(fallback2)
+    result3 = Cachex.Fallback.parse(fallback3)
+    result4 = Cachex.Fallback.parse(fallback4)
+    result5 = Cachex.Fallback.parse(fallback5)
+
+    # the first and fifth should use defaults
+    assert(result1 == %Cachex.Fallback{ })
+    assert(result5 == %Cachex.Fallback{ })
+
+    # the second should have an action but no state
+    assert(result2 == %Cachex.Fallback{ action: &String.reverse/1 })
+
+    # the third should have both an action and state
+    assert(result3 == %Cachex.Fallback{
+      action: &String.reverse/1,
+      state: {}
+    })
+
+    # the fourth should have a state but no action
+    assert(result4 == %Cachex.Fallback{ state: { } })
+  end
+
+end

--- a/test/cachex/options_test.exs
+++ b/test/cachex/options_test.exs
@@ -81,41 +81,38 @@ defmodule Cachex.OptionsTest do
     # grab a cache name
     name = Helper.create_name()
 
-    # define our fallbacks
-    valid_fb   = &(&1)
-    invalid_fb = "nop"
+    # define our falbacks
+    fallback1 = []
+    fallback2 = [ action: &String.reverse/1 ]
+    fallback3 = [ action: &String.reverse/1, state: {} ]
+    fallback4 = [ state: {} ]
+    fallback5 = &String.reverse/1
+    fallback6 = { }
 
     # parse both as options
-    { :ok, state1 } = Cachex.Options.parse(name, [ fallback:   valid_fb ])
-    { :ok, state2 } = Cachex.Options.parse(name, [ fallback: invalid_fb ])
+    { :ok, state1 } = Cachex.Options.parse(name, [ fallback: fallback1 ])
+    { :ok, state2 } = Cachex.Options.parse(name, [ fallback: fallback2 ])
+    { :ok, state3 } = Cachex.Options.parse(name, [ fallback: fallback3 ])
+    { :ok, state4 } = Cachex.Options.parse(name, [ fallback: fallback4 ])
+    { :ok, state5 } = Cachex.Options.parse(name, [ fallback: fallback5 ])
+    { :ok, state6 } = Cachex.Options.parse(name, [ fallback: fallback6 ])
 
-    # the first should have parsed
-    assert(state1.fallback == valid_fb)
+    # the first and sixth should use defaults
+    assert(state1.fallback == %Cachex.Fallback{ })
+    assert(state6.fallback == %Cachex.Fallback{ })
 
-    # but the second should be nil
-    assert(state2.fallback == nil)
-  end
+    # the second and fifth should have an action but no state
+    assert(state2.fallback == %Cachex.Fallback{ action: &String.reverse/1 })
+    assert(state5.fallback == %Cachex.Fallback{ action: &String.reverse/1 })
 
-  # This test will ensure that fallback arguments can be passed as options. We
-  # only accept a list of arguments, anything else should be defaulted to an empty
-  # list of arguments (to avoid having to check later in the execution flow).
-  test "parsing :fallback_args flags" do
-    # grab a cache name
-    name = Helper.create_name()
+    # the third should have both an action and state
+    assert(state3.fallback == %Cachex.Fallback{
+      action: &String.reverse/1,
+      state: {}
+    })
 
-    # parse out valid arguments
-    { :ok, state1 } = Cachex.Options.parse(name, [ fallback_args: [ 1, 2, 3 ] ])
-
-    # parse out invalid arguments
-    { :ok, state2 } = Cachex.Options.parse(name, [ fallback_args: "[1, 2, 3]" ])
-    { :ok, state3 } = Cachex.Options.parse(name, [ ])
-
-    # assert the first arguments are valid
-    assert(state1.fallback_args == [ 1, 2, 3 ])
-
-    # both the second and third options use defaults
-    assert(state2.fallback_args == [])
-    assert(state3.fallback_args == [])
+    # the fourth should have a state but no action
+    assert(state4.fallback == %Cachex.Fallback{ state: { } })
   end
 
   # This test will ensure that we can parse Hook values successfully. Hooks can


### PR DESCRIPTION
This fixes #84.

Changes involved:

This removes `:default_fallback` and `:fallback_args` completely. Going forward you should use a Keyword list with the `:fallback` option, which can contain the keys `:state` and `:action`. The `state` is provided as the second argument in your fallback, thus removing the `apply` overhead. If `state` is `nil`, it will not be provided. The `action` is a typical fallback functions as we know them in the 1.x line. Internally we now have a `Cachex.Fallback` struct used to store these values just to begin to future-proof a little bit.

You can still provide just a function rather than a list; internally this will become `[ action: function ]` before being parsed. This is to ease migration a little bit, but also just because it's nice to be able to inline functions.

Documentation has been updated, as well as migration, so this should be good to go pending CI.