### PR TITLE
Begin to implement custom command support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,13 @@ elixir:
   - 1.3.3
   - 1.2.6
 otp_release:
+  - 19.1
   - 19.0
   - 18.3
 before_install:
   - mix local.rebar --force
-before_script:
-  - epmd -daemon
 script:
-  - mix credo --all --format=oneline && mix coveralls --trace
+  - mix credo --all --format=oneline && mix coveralls.travis --trace
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: elixir
 elixir:
-  - 1.3.3
+  - 1.3.4
   - 1.2.6
 otp_release:
   - 19.1

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Hopefully you've noticed that in all examples above, we receive a `state` argume
 
 There are currently two ways to define cache limits, currently based only around the number of entries in a cache (although this will change in future). You can provide either an integer, or a `Cachex.Limit` structure to the `:limit` option in the Cachex interface.
 
-### Limit Structures
+#### Limit Structures
 
 A Limit struct consists of currently only 3 fields which dictate a limit and how it should be enforced. This allows the user to customize their eviction without getting too low-level. For example, here is a basic Limit structure. This is what passing an integer as the `:limit` option to a cache would unpack to internally:
 
@@ -235,7 +235,7 @@ Commands operate in such a way that they're marginally quicker than hand-writing
 
 Commands are defined on a per-cache basis, and you simply need to use the `:command` flag inside the `start_link/3` options to add your commands.
 
-### Command Definition
+#### Command Definition
 
 There are two types of commands which can be added, `:return` commands and `:modify` commands - they should be self explanatory. The former will return a value after your command transformation, whilst the latter will modify the value before placing it back into the cache. You can think of them as `read` and `write`, in effect.
 
@@ -268,7 +268,7 @@ I should mention that these command definitions are incredibly strict on purpose
 
 Finally it should be noted that if your key is missing, you will be provided with a `nil` value. If you're using a `:modify` command and receive a missing value, your modified value will only be written to the cache if it is not `nil` - this is to avoid forcing you to write keys which were previously missing.
 
-### Command Invocation
+#### Command Invocation
 
 Your entry point to running a command is `Cachex.invoke/4`, which has the signature `(cache, command, key, options)`. The command is just the name of your custom command, and the key is the key you wish to run it against (simple enough). If you provide an invalid command name, you will receive an error. There are currently no options available, they're just provided as future proofing.
 
@@ -461,7 +461,7 @@ Hooks are always notified sequentially as spawning another process for each has 
 
 A very common use case (and one of the reasons I built Cachex) is the desire to have Multi-Layered Caches. Multi-layering is the idea of a backing cache (i.e. something remote) which populates your local caches on misses. A typical pattern is using [Redis](http://redis.io) as a remote data store and replicating it locally in-memory for faster access.
 
-### Common Fallbacks
+#### Common Fallbacks
 
 Let's look at an example;
 
@@ -479,7 +479,7 @@ The use above will ensure that Cachex jumps to Redis to look for a key, **only i
 
 An effective approach with fallbacks is to use a TTL to make sure that your data doesn't become stale. In the case above, we can be sure that our data will never be more than 5 minutes out of date, whilst saving the impact of the network calls to Redis. Once a key expires locally after 5 minutes, Cachex will then jump back to Redis the next time the key is asked for. Of course the acceptable level of staleness depends on your use case, but generally this is a very useful behaviour as it allows applications to easily reap performance gains without sacrificing the ability to have a consistent backing store.
 
-### Specified Fallbacks
+#### Specified Fallbacks
 
 You may have noticed that the above example assumes that all keys behave in the same way. Naturally this isn't the case, and so all commands which allow for fallbacks also allow overrides in the call itself.
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Hopefully you've noticed that in all examples above, we receive a `state` argume
 
 There are currently two ways to define cache limits, currently based only around the number of entries in a cache (although this will change in future). You can provide either an integer, or a `Cachex.Limit` structure to the `:limit` option in the Cachex interface.
 
-#### Limit Structures
+### Limit Structures
 
 A Limit struct consists of currently only 3 fields which dictate a limit and how it should be enforced. This allows the user to customize their eviction without getting too low-level. For example, here is a basic Limit structure. This is what passing an integer as the `:limit` option to a cache would unpack to internally:
 
@@ -235,9 +235,9 @@ Commands operate in such a way that they're marginally quicker than hand-writing
 
 Commands are defined on a per-cache basis, and you simply need to use the `:command` flag inside the `start_link/3` options to add your commands.
 
-#### Command Definition
+### Command Definition
 
-There are two types of commands which can be added, `:return` commands and `:modify` commands - they should be self explanatory. The former will return a value after your command transformation, whilst the latter will modify the value before placing it back into the cache. You can think of them as `read` and `write`, in effect.
+There are two types of commands which can be added, `:return` commands and `:modify` commands - they should be self explanatory after looking at the example below. The former will return a value after your command transformation, whilst the latter will modify the value before placing it back into the cache. You can think of them as `read` and `write`, in effect.
 
 As an example, let's consider some List operations. Below there are two commands defined on a cache; one to retrieve the last value inside a List, and the other to pop the first element from a List.
 
@@ -268,9 +268,9 @@ I should mention that these command definitions are incredibly strict on purpose
 
 Finally it should be noted that if your key is missing, you will be provided with a `nil` value. If you're using a `:modify` command and receive a missing value, your modified value will only be written to the cache if it is not `nil` - this is to avoid forcing you to write keys which were previously missing.
 
-#### Command Invocation
+### Command Invocation
 
-Your entry point to running a command is `Cachex.invoke/4`, which has the signature `(cache, command, key, options)`. The command is just the name of your custom command, and the key is the key you wish to run it against (simple enough). If you provide an invalid command name, you will receive an error. There are currently no options available, they're just provided as future proofing.
+Your entry point to running a command is `Cachex.invoke/4`, which has the signature `(cache, key, command, options)`. The command is just the name of your custom command, and the key is the key you wish to run it against (simple enough). If you provide an invalid command name, you will receive an error. There are currently no options available, they're just provided as future proofing.
 
 Below is an example of several invocations of the `:lpop` example as defined above. This should give you a good enough introduction on how to call your commands:
 
@@ -287,10 +287,10 @@ Cachex.start_link(:my_cache, [
 ])
 
 { :ok, true } = Cachex.set(:my_cache, "my_list", [ 1, 2, 3 ])
-{ :ok,    1 } = Cachex.invoke(:my_cache, :lpop, "my_list")
-{ :ok,    2 } = Cachex.invoke(:my_cache, :lpop, "my_list")
-{ :ok,    3 } = Cachex.invoke(:my_cache, :lpop, "my_list")
-{ :ok,  nil } = Cachex.invoke(:my_cache, :lpop, "my_list")
+{ :ok,    1 } = Cachex.invoke(:my_cache, "my_list", :lpop)
+{ :ok,    2 } = Cachex.invoke(:my_cache, "my_list", :lpop)
+{ :ok,    3 } = Cachex.invoke(:my_cache, "my_list", :lpop)
+{ :ok,  nil } = Cachex.invoke(:my_cache, "my_list", :lpop)
 ```
 
 ## Execution Hooks
@@ -461,7 +461,7 @@ Hooks are always notified sequentially as spawning another process for each has 
 
 A very common use case (and one of the reasons I built Cachex) is the desire to have Multi-Layered Caches. Multi-layering is the idea of a backing cache (i.e. something remote) which populates your local caches on misses. A typical pattern is using [Redis](http://redis.io) as a remote data store and replicating it locally in-memory for faster access.
 
-#### Common Fallbacks
+### Common Fallbacks
 
 Let's look at an example;
 
@@ -479,7 +479,7 @@ The use above will ensure that Cachex jumps to Redis to look for a key, **only i
 
 An effective approach with fallbacks is to use a TTL to make sure that your data doesn't become stale. In the case above, we can be sure that our data will never be more than 5 minutes out of date, whilst saving the impact of the network calls to Redis. Once a key expires locally after 5 minutes, Cachex will then jump back to Redis the next time the key is asked for. Of course the acceptable level of staleness depends on your use case, but generally this is a very useful behaviour as it allows applications to easily reap performance gains without sacrificing the ability to have a consistent backing store.
 
-#### Specified Fallbacks
+### Specified Fallbacks
 
 You may have noticed that the above example assumes that all keys behave in the same way. Naturally this isn't the case, and so all commands which allow for fallbacks also allow overrides in the call itself.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Cachex is an extremely fast in-memory key/value store with support for many usef
 - Multi-layered caching/key fallbacks
 - Transactions and row locking
 - Asynchronous write operations
+- User command invocation
 
 All of these features are optional and are off by default so you can pick and choose those you wish to enable.
 
@@ -21,23 +22,26 @@ All of these features are optional and are off by default so you can pick and ch
     - [Interface](#interface)
     - [Options](#options)
 - [Migrating To v2.x](#migrating-to-v2)
-- [Cache Limits](#cache-limits)
-    - [Limit Structures](#limit-structures)
-- [Multi-Layered Caches](#multi-layered-caches)
-    - [Common Fallbacks](#common-fallbacks)
-    - [Specified Fallbacks](#specified-fallbacks)
-- [Execution Hooks](#execution-hooks)
-    - [Definition](#definition)
-    - [Registration](#registration)
-    - [Provisions](#provisions)
-    - [Performance](#performance)
-- [TTL Implementation](#ttl-implementation)
-    - [On Demand Expiration](#on-demand-expiration)
-    - [Janitors](#janitors)
 - [Action Blocks](#action-blocks)
     - [Execution Blocks](#execution-blocks)
     - [Transaction Blocks](#transaction-blocks)
     - [Things To Remember](#things-to-remember)
+- [Cache Limits](#cache-limits)
+    - [Limit Structures](#limit-structures)
+- [Custom Commands](#custom-commands)
+    - [Definition](#command-definition)
+    - [Invocation](#command-invocation)
+- [Execution Hooks](#execution-hooks)
+    - [Definition](#hook-definition)
+    - [Registration](#hook-registration)
+    - [Provisions](#hook-provisions)
+    - [Performance](#hook-performance)
+- [Multi-Layered Caches](#multi-layered-caches)
+    - [Common Fallbacks](#common-fallbacks)
+    - [Specified Fallbacks](#specified-fallbacks)
+- [TTL Implementation](#ttl-implementation)
+    - [Janitor Processes](#janitor-processes)
+    - [On Demand Expiration](#on-demand-expiration)
 - [Benchmarks](#benchmarks)
 - [Contributions](#contributions)
 
@@ -123,9 +127,10 @@ Caches can accept a list of options during initialization, which determine vario
 
 |      Options     |       Values       |                               Description                               |
 |:----------------:|:------------------:|:-----------------------------------------------------------------------:|
-|     ets_opts     |   list of options  |               A list of options to give to the ETS table.               |
+|     commands     |  list of commands  |   A list of custom commands to attach to the cache for invocation   |
 |    default_ttl   |     milliseconds   | A default expiration time for a key when being placed inside the cache. |
 |    disable_ode   |  `true` or `false` | Whether or not to disable on-demand expirations when reading back keys. |
+|     ets_opts     |   list of options  |               A list of options to give to the ETS table.               |
 |     fallback     |  Function or List  |   A function accepting a key which is used for multi-layered caching.   |
 |       hooks      |    list of Hooks   |    A list of execution hooks (see below) to listen on cache actions.    |
 |       limit      |  a Limit constuct  |     An integer or Limit struct to define the bounds of this cache.      |
@@ -138,6 +143,55 @@ For more information and examples, please see the official documentation on [Hex
 ## Migrating To v2
 
 There are a number of breaking changes in Cachex v2.0.0 for several reasons. Please read the [migration guide](https://github.com/zackehh/cachex/blob/master/MIGRATE.md) to learn about the changes and update your codebase. I tried to keep changes small, easy to learn, and only do them for the greater good, so there should be very little in a developer's codebase to modify (I hope).
+
+## Action Blocks
+
+As of `v0.9.0` support for execution blocks has been incorporated in Cachex. These blocks provide ways of ensuring many actions occur one after another (with some caveats, so read carefully). They come in two flavours; Execution Blocks and Transaction Blocks.
+
+#### Execution Blocks
+
+Execution Blocks were introduced to simply avoid the cost of passing state back and forth when it could be done in one step. For example, rather than:
+
+```elixir
+val1 = Cachex.get!(:my_cache, "key1")
+val2 = Cachex.get!(:my_cache, "key2")
+```
+
+You can do something like this:
+
+```elixir
+{ val1, val2 } = Cachex.execute!(:my_cache, fn(state) ->
+  v1 = Cachex.get!(worker, "key1")
+  v2 = Cachex.get!(worker, "key2")
+  { v1, v2 }
+end)
+```
+
+Although this looks more complicated it saves you a read of the internal Cachex state, which actually trims off a large amount of the overhead of a Cachex request.
+
+It should be noted that the consistency of these actions should not be relied upon. Even though you execute in a single block, you may still have cache actions occur between your calls inside the block. This is very important to keep in mind, and if this poses an issue, you might wish to move to [Transaction Blocks](#transaction-blocks) instead.
+
+#### Transaction Blocks
+
+Transaction Blocks are the consistent counterpart of Execution Blocks. They bind all actions into a transaction in order to ensure consistency even in distributed situations. This means that all actions you define in your transaction will execute one after another and are guaranteed successful. These blocks look almost identical to Execution Blocks, except that they require a list of keys to lock throughout their execution:
+
+```elixir
+{ val1, val2 } = Cachex.transaction!(:my_cache, [ "key1", "key2" ], fn(state) ->
+  v1 = Cachex.set!(worker, "key1", 1)
+  v2 = Cachex.set!(worker, "key2", 2)
+  { v1, v2 }
+end)
+```
+
+The major difference here is that it is guaranteed that no write operations occur on the locked keys whilst your transaction is executing. This means you can safely retrieve/modify/update values using custom logic without worrying that other processes are modifying your records in the meantime.
+
+Of course it should be noted (and obvious) that transactions have quite a bit of overhead to them, so only use them when you have to (e.g. the example above should not be using them). The overhead is much less than previous iterations of Cachex due to an in-built lock table rather than going via Mnesia.
+
+In addition, please note that transactions should only operate on the keys they have locked - if you write keys which haven't been locked, they're open to being written by external processes. This should always be checked appropriately when dealing with nested transactions.
+
+#### Things To Remember
+
+Hopefully you've noticed that in all examples above, we receive a `state` argument in our blocks. You **must** pass this to your `Cachex` calls, rather than the cache name. If you use the cache name inside your block, you lose all benefits of the block execution. Changes to Cachex in `v0.9.0` allow you to pass the `state` argument to the interface to safely avoid this issue.
 
 ## Cache Limits
 
@@ -173,52 +227,71 @@ You should be aware that eviction is not instant - it happens in reaction to eve
 
 It should be noted that although LRW is the only policy implemented at this time, you can control LRU policies by using `Cachex.touch/2` to do a write on a key without affecting the value or TTL. Using `Cachex.touch/2` and the LRW policy is likely how an LRU policy would work regardless.
 
-## Multi-Layered Caches
+## Custom Commands
 
-A very common use case (and one of the reasons I built Cachex) is the desire to have Multi-Layered Caches. Multi-layering is the idea of a backing cache (i.e. something remote) which populates your local caches on misses. A typical pattern is using [Redis](http://redis.io) as a remote data store and replicating it locally in-memory for faster access.
+As of v2.0.0, Cachex can have custom commands attached to a cache to simplify common logic without having to channel all of your cache calls through a specific module. Cache commands are provided in order to make it easy to extend Cachex with operations specific to your application logic, rather than bloating the library with commands that aren't always needed.
 
-### Common Fallbacks
+Commands operate in such a way that they're marginally quicker than hand-writing your own wrapper functions, but only very slightly. You should aim to set only general actions as cache commands, whilst keeping extremely custom actions outside of the cache. In future, Cachex may ship with some built in commands for common functionality.
 
-Let's look at an example;
+Commands are defined on a per-cache basis, and you simply need to use the `:command` flag inside the `start_link/3` options to add your commands.
 
-Assume you have a backing Redis cache with a fairly large amount of keys, and you wish to cache it locally to avoid the network calls (let's say you're doing it thousands of times a second). Cachex can do this easily be providing a **fallback** action to take when a key is missing. This is configured during cache initialization using the `fallback` option, as below:
+### Command Definition
 
-```elixir
-# initialize the cache instance
-{ :ok, pid } = Cachex.start_link(:redis_memory_layer, [ default_ttl: :timer.minutes(5), fallback: &RedisClient.get/1 ])
+There are two types of commands which can be added, `:return` commands and `:modify` commands - they should be self explanatory. The former will return a value after your command transformation, whilst the latter will modify the value before placing it back into the cache. You can think of them as `read` and `write`, in effect.
 
-# status will equal :loaded if Redis was hit, otherwise :ok when successful
-{ status, information } = Cachex.get(:redis_memory_layer, "my_key")
-```
-
-The use above will ensure that Cachex jumps to Redis to look for a key, **only if** it doesn't have a copy locally. If one does exist locally, Cachex will use that instead.
-
-An effective approach with fallbacks is to use a TTL to make sure that your data doesn't become stale. In the case above, we can be sure that our data will never be more than 5 minutes out of date, whilst saving the impact of the network calls to Redis. Once a key expires locally after 5 minutes, Cachex will then jump back to Redis the next time the key is asked for. Of course the acceptable level of staleness depends on your use case, but generally this is a very useful behaviour as it allows applications to easily reap performance gains without sacrificing the ability to have a consistent backing store.
-
-### Specified Fallbacks
-
-You may have noticed that the above example assumes that all keys behave in the same way. Naturally this isn't the case, and so all commands which allow for fallbacks also allow overrides in the call itself.
-
-Using another example, let's assume that you need to read information from a database to service a public API. The issue is that the query is expensive and so you want to cache it locally for 5 minutes to avoid overloading your database. To do this with Cachex, you would simply specify a TTL of 5 minutes on your cache, and use a fallback to read from your database.
+As an example, let's consider some List operations. Below there are two commands defined on a cache; one to retrieve the last value inside a List, and the other to pop the first element from a List.
 
 ```elixir
-# initialize our database client
-{ :ok, db } = initialize_database_client()
+last = &List.last/1
+lpop = fn
+  ([ head | tail ]) ->
+    { head, tail }
+  ([ ] = list) ->
+    {  nil, list }
+end
 
-# initialize the cache instance
-{ :ok, pid } = Cachex.start_link(:info_cache, [ default_ttl: :timer.minutes(5), fallback: [ state: db ] ])
-
-# status will equal :loaded if the database was hit, otherwise :ok when successful
-{ status, information } = Cachex.get(:info_cache, "/api/v1/packages", fallback: fn(key, db) ->
-  Database.query_all_packages(db)
-end)
+Cachex.start_link(:my_cache, [
+  commands: [
+    last: { :return, last },
+    lpop: { :modify, lpop }
+  ]
+])
 ```
 
-The above is a multi-layered cache which only hits the database **at most** every 5 minutes, and hits local memory in the meantime (retrieving the exact same data as was returned from your database). This allows you to easily lower the pressure on your backing systems as the context of your call requires - for example in the use case above, we can totally ignore the key argument as the function is only ever invoked on that call.
+Retrieving the last item in a List is clearly just a read operation, and so we tag the command with a `:return` atom. This just means that whatever the `:last` command returns is returned, basically allowing you to transform cache values. This should be a very natural concept (I hope, at least).
 
-Also note that this example demonstrates how you can provide state to your fallback functions by providing a Keyword List against the `:fallback` option. This list can contain the `:state` and `:action` keys to further customize how fallbacks work. The state is provided as a second argument to the action in the case it is not set to `nil`.
+The `:lpop` command is slightly more complicated, but provides a good example of the types of sugar you can implement with this interface. The return value of a `:modify` command **must** be a 2-element Tuple, with the return value on the left and the modified value on the right. For example, if you return a value of `{ 1, 2 }` then `1` would be the return type of your `invoke/4` call, and `2` would be the new value set inside the cache.
 
-As demonstrated in the [Common Fallbacks](#common-fallbacks) section above, providing a function instead of a List is internally converted to `[ action: &RedisClient.get/1 ]`. It is simply shorthand in case you do not wish to provide a state.
+In the example above, we're simply "popping" the first element from the List - meaning that we're retrieving it whilst removing it at the same time. To do this, we return the `head` as the first element in the Tuple, and return the `tail` as the second element in the Tuple - thus easily allowing us to pop elements without having to do anything too fancy, and without code duplication.
+
+I should mention that these command definitions are incredibly strict on purpose. If you don't provide a valid `{ :modify | :return, fun/1 }` syntax, you will receive an error. In addition, if your `:modify` function returns anything other than a 2-element Tuple, your app will crash (there is no good way to recover this).
+
+Finally it should be noted that if your key is missing, you will be provided with a `nil` value. If you're using a `:modify` command and receive a missing value, your modified value will only be written to the cache if it is not `nil` - this is to avoid forcing you to write keys which were previously missing.
+
+### Command Invocation
+
+Your entry point to running a command is `Cachex.invoke/4`, which has the signature `(cache, command, key, options)`. The command is just the name of your custom command, and the key is the key you wish to run it against (simple enough). If you provide an invalid command name, you will receive an error. There are currently no options available, they're just provided as future proofing.
+
+Below is an example of several invocations of the `:lpop` example as defined above. This should give you a good enough introduction on how to call your commands:
+
+```elixir
+lpop = fn
+  ([ head | tail ]) ->
+    { head, tail }
+  ([ ] = list) ->
+    {  nil, list }
+end
+
+Cachex.start_link(:my_cache, [
+  commands: [ lpop: { :modify, lpop } ]
+])
+
+{ :ok, true } = Cachex.set(:my_cache, "my_list", [ 1, 2, 3 ])
+{ :ok,    1 } = Cachex.invoke(:my_cache, :lpop, "my_list")
+{ :ok,    2 } = Cachex.invoke(:my_cache, :lpop, "my_list")
+{ :ok,    3 } = Cachex.invoke(:my_cache, :lpop, "my_list")
+{ :ok,  nil } = Cachex.invoke(:my_cache, :lpop, "my_list")
+```
 
 ## Execution Hooks
 
@@ -234,7 +307,7 @@ Cachex.get(:my_cache, "key") == { :get, [ :my_cache, "key" ] }
 
 Cachex uses the typical `GenServer` pattern, and as such you get most of the typical interfaces. There are a couple of differences, but they're detailed below.
 
-#### Definition
+#### Hook Definition
 
 Hooks are quite simply a small abstraction above the existing `GenServer` which ships with Elixir. Cachex tweaks a couple of minor things related to synchronous execution and argument format, but nothing too special. Below is an example of a very basic hook implementation:
 
@@ -285,7 +358,7 @@ end
 
 As we're using a `GenServer`, you have access to all of the usual callback functions from the `GenServer` module. This is an improvement over v1.x, where only `GenEvent` functions were available. As such, make sure your `handle_call/3`, `handle_cast/2` and `handle_info/2` functions return appropriate values.
 
-#### Registration
+#### Hook Registration
 
 To register hooks with Cachex, they must be passed in when setting up a cache in the call to `Cachex.start_link/3` (or in your Supervisor). This looks something like the following:
 
@@ -337,7 +410,7 @@ These fields translate to the following:
 - `max_timeout` has no effect if the hook is not being executed in a synchronous form.
 - `module` is the only required argument, as there's no logical default to set if not provided.
 
-#### Provisions
+#### Hook Provisions
 
 There are some things which cannot be given to your hook on startup. For example if you wanted access to a cache worker in your hook, you would hit a dead end because all hooks are started before any worker processes. For this reason `v1.0.0` added a `:provide` option which takes a list of atoms which specify things to be provided to your hook.
 
@@ -378,27 +451,64 @@ Cachex.start_link(:my_cache, [ hooks: hook ])
 
 The message you receive in `handle_info/2` will always be `{ :provision, { provide_option, value } }` where `provide_option` is equal to the atom you've asked for (in this case `:state`). Be aware that this modification event may be fired multiple times if the internal worker structure has changed for any reason (for example when extra nodes are added to the cluster).
 
-#### Performance
+#### Hook Performance
 
 Due to the way hooks are implemented and notified internally, there is only a very minimal overhead to defining a hook (usually around a microsecond per definition). Naturally if you define a synchronous hook then the performance depends entirely on the actions taken inside the hook (up until the timeout).
 
 Hooks are always notified sequentially as spawning another process for each has far too much overhead, and so you should keep this in mind when using synchronous hooks as 3 hooks which all take a second to execute will cause the Cachex action to take at least 3 seconds before completing.
 
+## Multi-Layered Caches
+
+A very common use case (and one of the reasons I built Cachex) is the desire to have Multi-Layered Caches. Multi-layering is the idea of a backing cache (i.e. something remote) which populates your local caches on misses. A typical pattern is using [Redis](http://redis.io) as a remote data store and replicating it locally in-memory for faster access.
+
+### Common Fallbacks
+
+Let's look at an example;
+
+Assume you have a backing Redis cache with a fairly large amount of keys, and you wish to cache it locally to avoid the network calls (let's say you're doing it thousands of times a second). Cachex can do this easily be providing a **fallback** action to take when a key is missing. This is configured during cache initialization using the `fallback` option, as below:
+
+```elixir
+# initialize the cache instance
+{ :ok, pid } = Cachex.start_link(:redis_memory_layer, [ default_ttl: :timer.minutes(5), fallback: &RedisClient.get/1 ])
+
+# status will equal :loaded if Redis was hit, otherwise :ok when successful
+{ status, information } = Cachex.get(:redis_memory_layer, "my_key")
+```
+
+The use above will ensure that Cachex jumps to Redis to look for a key, **only if** it doesn't have a copy locally. If one does exist locally, Cachex will use that instead.
+
+An effective approach with fallbacks is to use a TTL to make sure that your data doesn't become stale. In the case above, we can be sure that our data will never be more than 5 minutes out of date, whilst saving the impact of the network calls to Redis. Once a key expires locally after 5 minutes, Cachex will then jump back to Redis the next time the key is asked for. Of course the acceptable level of staleness depends on your use case, but generally this is a very useful behaviour as it allows applications to easily reap performance gains without sacrificing the ability to have a consistent backing store.
+
+### Specified Fallbacks
+
+You may have noticed that the above example assumes that all keys behave in the same way. Naturally this isn't the case, and so all commands which allow for fallbacks also allow overrides in the call itself.
+
+Using another example, let's assume that you need to read information from a database to service a public API. The issue is that the query is expensive and so you want to cache it locally for 5 minutes to avoid overloading your database. To do this with Cachex, you would simply specify a TTL of 5 minutes on your cache, and use a fallback to read from your database.
+
+```elixir
+# initialize our database client
+{ :ok, db } = initialize_database_client()
+
+# initialize the cache instance
+{ :ok, pid } = Cachex.start_link(:info_cache, [ default_ttl: :timer.minutes(5), fallback: [ state: db ] ])
+
+# status will equal :loaded if the database was hit, otherwise :ok when successful
+{ status, information } = Cachex.get(:info_cache, "/api/v1/packages", fallback: fn(key, db) ->
+  Database.query_all_packages(db)
+end)
+```
+
+The above is a multi-layered cache which only hits the database **at most** every 5 minutes, and hits local memory in the meantime (retrieving the exact same data as was returned from your database). This allows you to easily lower the pressure on your backing systems as the context of your call requires - for example in the use case above, we can totally ignore the key argument as the function is only ever invoked on that call.
+
+Also note that this example demonstrates how you can provide state to your fallback functions by providing a Keyword List against the `:fallback` option. This list can contain the `:state` and `:action` keys to further customize how fallbacks work. The state is provided as a second argument to the action in the case it is not set to `nil`.
+
+As demonstrated in the [Common Fallbacks](#common-fallbacks) section above, providing a function instead of a List is internally converted to `[ action: &RedisClient.get/1 ]`. It is simply shorthand in case you do not wish to provide a state.
+
 ## TTL Implementation
 
 Cachex implements a few different ways of working with key expiration, namely the background TTL loop and on-demand key expiration. Separately these two techniques aren't enough to provide an efficient system as your keyspace would either grow too large due to keys not being accessed and purged on access, or you would be able to retrieve values which should have expired. Cachex opts for a combination of both in order to ensure consistency whilst also reducing pressure on things like table scans.
 
-#### On Demand Expiration
-
-Keys have an internal touch time and TTL associated with them, and these values do not change unless triggered explicitly by a Cachex call. This means that these values come back when we access a key, and allows us to very easily check if the key should have expired before returning it to the user. If this is the case, we actually fire off a deletion of the key before returning the `nil` value to the user.
-
-This means that at any point, if you have the TTL worker disabled, you can realistically never retrieve an expired key. This provides the ability to run the TTL worker less frequently, instead of having to have a tight loop in order to make sure that values can't be stale.
-
-Of course, if you have the TTL worker disabled you need to be careful of a growing cache size due to keys being added and then never being accessed again. This is fine if you have a very restrictive keyset, but for arbitrary keys this is probably not what you want.
-
-Although the overhead of on-demand expiration is minimal, as of v0.10.0 it can be disabled using the `disable_ode` option inside `start/1` or `start_link/2`. This is useful if you have a Janitor running and don't mind keys existing a little beyond their expiration (for example if  TTL is being used purely as a means to control memory usage). The main advantage of disabling ODE is that the execution time of any given read operation is more predictable due to avoiding the case where some reads also evict the key.
-
-#### Janitors
+#### Janitor Processes
 
 Cachex also enables a background process (nicknamed the `Janitor`) which will purge the internal table every so often. The Janitor operates using **full-table scans** and so you should be relatively careful about how often you run it. The interval that this process runs can be controlled, and Janitors exist on a per-cache basis (i.e. each cache has its own Janitor).
 
@@ -413,58 +523,19 @@ There are several rules to be aware of when setting up the interval:
 
 It should be noted that this is a rolling value which is set **on completion** of a run. This means that if you schedule the Janitor to run every 1ms, it will be 1ms after a successful run, rather than starting every 1ms. This may become configurable in the future if there's demand for it, but for now rolling seems to make the most sense.
 
-## Action Blocks
+#### On Demand Expiration
 
-As of `v0.9.0` support for execution blocks has been incorporated in Cachex. These blocks provide ways of ensuring many actions occur one after another (with some caveats, so read carefully). They come in two flavours; Execution Blocks and Transaction Blocks.
+Keys have an internal touch time and TTL associated with them, and these values do not change unless triggered explicitly by a Cachex call. This means that these values come back when we access a key, and allows us to very easily check if the key should have expired before returning it to the user. If this is the case, we actually fire off a deletion of the key before returning the `nil` value to the user.
 
-#### Execution Blocks
+This means that at any point, if you have the Janitor disabled, you can realistically never retrieve an expired key. This provides the ability to run the Janitor less frequently, instead of having to have a tight loop in order to make sure that values can't be stale.
 
-Execution Blocks were introduced to simply avoid the cost of passing state back and forth when it could be done in one step. For example, rather than:
+Of course, if you have the Janitor disabled you need to be careful of a growing cache size due to keys being added and then never being accessed again. This is fine if you have a very restrictive keyset, but for arbitrary keys this is probably not what you want.
 
-```elixir
-val1 = Cachex.get!(:my_cache, "key1")
-val2 = Cachex.get!(:my_cache, "key2")
-```
-
-You can do something like this:
-
-```elixir
-{ val1, val2 } = Cachex.execute!(:my_cache, fn(state) ->
-  v1 = Cachex.get!(worker, "key1")
-  v2 = Cachex.get!(worker, "key2")
-  { v1, v2 }
-end)
-```
-
-Although this looks more complicated it saves you a read of the internal Cachex state, which actually trims off a large amount of the overhead of a Cachex request.
-
-It should be noted that the consistency of these actions should not be relied upon. Even though you execute in a single block, you may still have cache actions occur between your calls inside the block. This is very important to keep in mind, and if this poses an issue, you might wish to move to [Transaction Blocks](#transaction-blocks) instead.
-
-#### Transaction Blocks
-
-Transaction Blocks are the consistent counterpart of Execution Blocks. They bind all actions into a transaction in order to ensure consistency even in distributed situations. This means that all actions you define in your transaction will execute one after another and are guaranteed successful. These blocks look almost identical to Execution Blocks, except that they require a list of keys to lock throughout their execution:
-
-```elixir
-{ val1, val2 } = Cachex.transaction!(:my_cache, [ "key1", "key2" ], fn(state) ->
-  v1 = Cachex.set!(worker, "key1", 1)
-  v2 = Cachex.set!(worker, "key2", 2)
-  { v1, v2 }
-end)
-```
-
-The major difference here is that it is guaranteed that no write operations occur on the locked keys whilst your transaction is executing. This means you can safely retrieve/modify/update values using custom logic without worrying that other processes are modifying your records in the meantime.
-
-Of course it should be noted (and obvious) that transactions have quite a bit of overhead to them, so only use them when you have to (e.g. the example above should not be using them). The overhead is much less than previous iterations of Cachex due to an in-built lock table rather than going via Mnesia.
-
-In addition, please note that transactions should only operate on the keys they have locked - if you write keys which haven't been locked, they're open to being written by external processes. This should always be checked appropriately when dealing with nested transactions.
-
-#### Things To Remember
-
-Hopefully you've noticed that in all examples above, we receive a `state` argument in our blocks. You **must** pass this to your `Cachex` calls, rather than the cache name. If you use the cache name inside your block, you lose all benefits of the block execution. Changes to Cachex in `v0.9.0` allow you to pass the `state` argument to the interface to safely avoid this issue.
+Although the overhead of on-demand expiration is minimal, as of v0.10.0 it can be disabled using the `disable_ode` option inside `start/1` or `start_link/2`. This is useful if you have a Janitor running and don't mind keys existing a little beyond their expiration (for example if  TTL is being used purely as a means to control memory usage). The main advantage of disabling ODE is that the execution time of any given read operation is more predictable due to avoiding the case where some reads also evict the key.
 
 ## Benchmarks
 
-There are some very trivial benchmarks available using [Benchfella](https://github.com/alco/benchfella) in the `bench/` directory. Please use the median to gauge performance as the averages shown have wild error bounds (due to operations being so fast and hard to calculate). You can run the benchmarks using the following command:
+There are some very trivial benchmarks available using [Benchfella](https://github.com/alco/benchfella) in the `bench/` directory. You can run the benchmarks using the following command:
 
 ```bash
 # default benchmarks, no modifiers

--- a/coveralls.json
+++ b/coveralls.json
@@ -2,6 +2,7 @@
   "default_stop_words": [
     "defmodule",
     "defrecord",
+    "defexception",
     "defimpl",
     "defprotocol",
     "defstruct",

--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -768,14 +768,14 @@ defmodule Cachex do
 
       iex> Cachex.start_link(:my_cache, [ commands: [ last: { :return, &List.last/1 } ] ])
       iex> Cachex.set(:my_cache, "my_list", [ 1, 2, 3 ])
-      iex> Cachex.invoke(:my_cache, :last, "my_list")
+      iex> Cachex.invoke(:my_cache, "my_list", :last)
       { :ok, 3 }
 
   """
-  @spec invoke(cache, atom, any, Keyword.t) :: any
-  defwrap invoke(cache, cmd, key, options \\ []) when is_list(options) do
+  @spec invoke(cache, any, atom, Keyword.t) :: any
+  defwrap invoke(cache, key, cmd, options \\ []) when is_list(options) do
     State.enforce(cache, state) do
-      Actions.Invoke.execute(state, cmd, key, options)
+      Actions.Invoke.execute(state, key, cmd, options)
     end
   end
 

--- a/lib/cachex/actions.ex
+++ b/lib/cachex/actions.ex
@@ -37,7 +37,7 @@ defmodule Cachex.Actions do
       { unquote(func_name), [ unquote_splicing(args_without_state) ] }
     end
 
-    quote location: :keep do
+    quote do
       def execute(unquote_splicing(arguments)) do
         local_opts  = var!(options)
         local_state = var!(state)

--- a/lib/cachex/actions/get_and_update.ex
+++ b/lib/cachex/actions/get_and_update.ex
@@ -9,12 +9,11 @@ defmodule Cachex.Actions.GetAndUpdate do
 
   # add some action aliases
   alias Cachex.Actions.Get
-  alias Cachex.Actions.Set
-  alias Cachex.Actions.Update
 
   # add other aliases
   alias Cachex.LockManager
   alias Cachex.State
+  alias Cachex.Util
 
   @doc """
   Retrieves a value and updates it inside the cache.
@@ -38,19 +37,12 @@ defmodule Cachex.Actions.GetAndUpdate do
 
       tempv = update_fun.(value)
 
-      write_mod(status, state, key, tempv)
+      Util
+        .write_mod(status)
+        .execute(state, key, tempv, @notify_false)
 
       { status, tempv }
     end)
   end
-
-  # Writes the record using the appropriate function. If the key exists in the
-  # cache, we use an update operation, otherwise we use a set operation. This
-  # is kinda ugly because they both use the same arguments, but rather than using
-  # an `apply/3` call this should be a little more performant.
-  defp write_mod(:missing, state, key, tempv),
-    do: Set.execute(state, key, tempv, @notify_false)
-  defp write_mod(_others_, state, key, tempv),
-    do: Update.execute(state, key, tempv, @notify_false)
 
 end

--- a/lib/cachex/actions/invoke.ex
+++ b/lib/cachex/actions/invoke.ex
@@ -1,0 +1,66 @@
+defmodule Cachex.Actions.Invoke do
+  @moduledoc false
+  # This module allows invocation of custom cache commands. A cache command must
+  # be of the form `{ :return | :modify, fn/1 }` and reside inside the `:commands`
+  # key of the State struct. Invocations which modify are carried out inside a
+  # Transaction context to ensure consistency. Please see the project documentation
+  # for more details.
+
+  # we need our imports
+  use Cachex.Actions
+
+  # add some aliases
+  alias Cachex.Actions.Get
+  alias Cachex.LockManager
+  alias Cachex.State
+  alias Cachex.Util
+
+  @doc """
+  Invokes a custom command on a cache.
+
+  This allows the developer to attach common functions directly to the cache, in
+  order to easily share logic around a codebase without having to write a module.
+
+  Invocation passes the value for a given key through to the custom command, and
+  takes action based on the type of command being executed and the return value
+  of the command.
+
+  There are currently no options accepted here, but it's required as an argument
+  in order to future-proof the arity.
+  """
+  defaction invoke(%State{ commands: commands } = state, cmd, key, options) do
+    commands
+    |> Map.get(cmd)
+    |> do_invoke(state, key)
+  end
+
+  # Carries out an invocation. If the command retrieved is invalid, we just pass
+  # an error back to the caller instead of trying to do anything too clever.
+  defp do_invoke(nil, _state, _key) do
+    @error_invalid_command
+  end
+
+  # In the case of a `:return` function, we just pull the value from the cache
+  # and pass it off to be transformed before the result is passed back.
+  defp do_invoke({ :return, fun }, state, key) do
+    { _status_, value } = Get.execute(state, key, @notify_false)
+    { :ok, fun.(value) }
+  end
+
+  # In the case of `:modify` functions, we initialize a locking context to ensure
+  # consistency, before retrieving the value of the key. This value is then passed
+  # through to the command and the return value is used to dictate the new value
+  # to be written to the cache, as well as the value to return.
+  defp do_invoke({ :modify, fun }, state, key) do
+    LockManager.transaction(state, [ key ], fn ->
+      { status, value } = Get.execute(state, key, @notify_false)
+      { return, tempv } = fun.(value)
+
+      Util
+        .write_mod(status)
+        .execute(state, key, tempv, @notify_false)
+
+      { :ok, return }
+    end)
+  end
+end

--- a/lib/cachex/actions/invoke.ex
+++ b/lib/cachex/actions/invoke.ex
@@ -28,7 +28,7 @@ defmodule Cachex.Actions.Invoke do
   There are currently no options accepted here, but it's required as an argument
   in order to future-proof the arity.
   """
-  defaction invoke(%State{ commands: commands } = state, cmd, key, options) do
+  defaction invoke(%State{ commands: commands } = state, key, cmd, options) do
     commands
     |> Map.get(cmd)
     |> do_invoke(state, key)

--- a/lib/cachex/actions/stats.ex
+++ b/lib/cachex/actions/stats.ex
@@ -38,9 +38,8 @@ defmodule Cachex.Actions.Stats do
   # Uses a stats hook to retrieve pieces of the statistics container from the
   # running stats hook. If no hook is provided, we return an error because the
   # Stats hook is not running, meaning that record_stats is disabled.
-  defp handle_hook(nil, _options) do
-    @error_stats_disabled
-  end
+  defp handle_hook(nil, _options),
+    do: @error_stats_disabled
   defp handle_hook(%Hook{ ref: ref }, options) do
     stats = Cachex.Hook.Stats.retrieve(ref)
 

--- a/lib/cachex/commands.ex
+++ b/lib/cachex/commands.ex
@@ -1,0 +1,34 @@
+defmodule Cachex.Commands do
+  @moduledoc false
+  # This module controls basic command parsing for commands provided in options
+  # for a cache. This is moved into a separate module in order to make it easier
+  # to keep the logic separate. This module does not currently control execution,
+  # but just the parsing and validation of provided commands.
+
+  # we need our constants
+  use Cachex.Constants
+
+  @doc """
+  Parses a Keyword list of commands into a Map of commands.
+
+  This can return an error if there is an invalid command structure inside the
+  command list.
+  """
+  def parse(cmds) when is_list(cmds) do
+    with :ok <- validate(cmds), do: { :ok, Enum.into(cmds, %{}) }
+  end
+
+  @doc """
+  Validates a list of commands and their structure.
+
+  This will stop and return an error on the first instance of an invalid command.
+  """
+  def validate([ { _, { tag, fun } } | tl ])
+  when is_function(fun, 1) and tag in [ :return, :modify ],
+    do: validate(tl)
+  def validate([ ]),
+    do: :ok
+  def validate(_inv),
+    do: @error_invalid_command
+
+end

--- a/lib/cachex/constants.ex
+++ b/lib/cachex/constants.ex
@@ -5,12 +5,13 @@ defmodule Cachex.Constants do
 
   @doc false
   defmacro __using__(_) do
-    quote location: :keep do
+    quote do
       @notify_false             [ notify: false ]
       @purge_override_call      { :purge, [[]] }
       @purge_override_result    { :ok, 1 }
       @purge_override           [ via: @purge_override_call, hook_result: @purge_override_result ]
 
+      @error_invalid_command    { :error, :invalid_command }
       @error_invalid_hook       { :error, :invalid_hook }
       @error_invalid_match      { :error, :invalid_match }
       @error_invalid_name       { :error, :invalid_name }

--- a/lib/cachex/errors.ex
+++ b/lib/cachex/errors.ex
@@ -14,6 +14,8 @@ defmodule Cachex.Errors do
   If an invalid error identifer is provided, there will simply be an error due
   to no matching function head (and this is intended).
   """
+  def long_form(:invalid_command),
+    do: "Invalid command definition provided"
   def long_form(:invalid_hook),
     do: "Invalid hook definition provided"
   def long_form(:invalid_match),

--- a/lib/cachex/macros.ex
+++ b/lib/cachex/macros.ex
@@ -77,11 +77,9 @@ defmodule Cachex.Macros do
 
   # Converts various function input to an unsafe version by adding a trailing
   # "!" to the function name.
-  defp gen_unsafe({ :when, ctx, [ head | tail ] }) do
-    { :when, ctx, [ gen_unsafe(head) | tail ]}
-  end
-  defp gen_unsafe({ name, ctx, args }) do
-    { Util.atom_append(name, "!"), ctx, args }
-  end
+  defp gen_unsafe({ :when, ctx, [ head | tail ] }),
+    do: { :when, ctx, [ gen_unsafe(head) | tail ]}
+  defp gen_unsafe({ name, ctx, args }),
+    do: { Util.atom_append(name, "!"), ctx, args }
 
 end

--- a/lib/cachex/state.ex
+++ b/lib/cachex/state.ex
@@ -20,6 +20,7 @@ defmodule Cachex.State do
 
   # internal state struct
   defstruct cache: nil,             # the name of the cache
+            commands: %{},          # any custom commands attached to the cache
             disable_ode: false,     # whether we disable on-demand expiration
             ets_opts: [],           # any options to give to ETS
             default_ttl: nil,       # any default ttl values to use

--- a/test/cachex/actions/invoke_test.exs
+++ b/test/cachex/actions/invoke_test.exs
@@ -1,59 +1,125 @@
 defmodule Cachex.Actions.InvokeTest do
   use CachexCase
 
-  test "invoking custom commands" do
-    # create a list left pop
-    lpop = fn([ head | tail ]) ->
-      { head, tail }
-    end
-
-    # create a list right pop
-    rpop = fn(list) ->
-      { List.last(list), :lists.droplast(list) }
-    end
-
+  # This test covers the ability to run commands tagged with the `:modify` type.
+  # We test that we can return our own values whilst modifying Lists. There is
+  # also coverage here for checking that the same value is not written to the
+  # cache if it remains unchanged - but this can only be seen using coverage tools
+  # due to the nature of the backing writes.
+  test "invoking :modify commands" do
     # create a test cache
     cache = Helper.create_cache([
       commands: [
-        last: { :return, &List.last/1 },
-        lpop: { :modify, lpop },
-        rpop: { :modify, rpop }
+        lpop: { :modify, &lpop/1 },
+        rpop: { :modify, &rpop/1 }
       ]
     ])
 
     # set a list inside the cache
-    { :ok, true } = Cachex.set(cache, "list", [ 1, 2, 3, 4, 5 ])
+    { :ok, true } = Cachex.set(cache, "list", [ 1, 2, 3, 4 ])
 
     # retrieve the raw record
     { "list", touched, nil, _val } = Cachex.inspect!(cache, { :record, "list" })
 
     # execute some custom commands
-    last1 = Cachex.invoke(cache, :last, "list")
     lpop1 = Cachex.invoke(cache, :lpop, "list")
     lpop2 = Cachex.invoke(cache, :lpop, "list")
     rpop1 = Cachex.invoke(cache, :rpop, "list")
     rpop2 = Cachex.invoke(cache, :rpop, "list")
-    last2 = Cachex.invoke(cache, :last, "list")
 
     # verify that all results are as expected
-    assert(last1 == { :ok, 5 })
     assert(lpop1 == { :ok, 1 })
     assert(lpop2 == { :ok, 2 })
-    assert(rpop1 == { :ok, 5 })
-    assert(rpop2 == { :ok, 4 })
-    assert(last2 == { :ok, 3 })
+    assert(rpop1 == { :ok, 4 })
+    assert(rpop2 == { :ok, 3 })
 
     # retrieve the raw record again
     inspect1 = Cachex.inspect(cache, { :record, "list" })
 
     # verify the touched time was unchanged
-    assert(inspect1 == { :ok, { "list", touched, nil, [ 3 ] }})
+    assert(inspect1 == { :ok, { "list", touched, nil, [ ] }})
+
+    # pop some extras to test avoiding writes
+    lpop3 = Cachex.invoke(cache, :lpop, "list")
+    rpop3 = Cachex.invoke(cache, :rpop, "list")
+
+    # verify we stayed the same
+    assert(lpop3 == { :ok, nil })
+    assert(rpop3 == { :ok, nil })
+  end
+
+  # This test covers the ability to run commands tagged with the `:return type.
+  # We simply test that we can return values as expected, as this is a very simple
+  # implementation which doesn't have much room for error beyond user-created issues.
+  test "invoking :return commands" do
+    # create a test cache
+    cache = Helper.create_cache([
+      commands: [
+        last: { :return, &List.last/1 }
+      ]
+    ])
+
+    # define a validation function
+    validate = fn(list, expected) ->
+      # set a list inside the cache
+      { :ok, true } = Cachex.set(cache, "list", list)
+
+      # retrieve the last value
+      last = Cachex.invoke(cache, :last, "list")
+
+      # compare with the expected
+      assert(last == { :ok, expected })
+    end
+
+    # ensure basic list works
+    validate.([ 1, 2, 3, 4, 5 ], 5)
+    validate.([ 1 ], 1)
+
+    # ensure empty list works
+    validate.([ ], nil)
+  end
+
+  # This test just makes sure that we correctly return an error in case the called
+  # function is not a valid cache function. We make sure that missing functions
+  # fail, as well as commands which have been badly formed due to arity or tag.
+  test "invoking invalid commands" do
+    # create a test cache
+    cache = Helper.create_cache()
+
+    # retrieve the state
+    state = Cachex.State.get(cache)
+
+    # modify the state to have fake commands
+    state = %Cachex.State{ state | commands: %{
+      fake_mod: { :modify, &({ &1, &2 }) },
+      fake_ret: { :return, &({ &1, &2 }) }
+    } }
 
     # try to invoke a missing command
-    invoke1 = Cachex.invoke(cache, :invoke, "heh")
+    invoke1 = Cachex.invoke(state, :invoke, "heh")
 
-    # it should be an error
+    # try to invoke bad arity commands
+    invoke2 = Cachex.invoke(state, :fake_mod, "heh")
+    invoke3 = Cachex.invoke(state, :fake_ret, "heh")
+
+    # all should error
     assert(invoke1 == { :error, :invalid_command })
+    assert(invoke2 == { :error, :invalid_command })
+    assert(invoke3 == { :error, :invalid_command })
   end
+
+  # A simple left pop for a List to remove the head and return the tail as the
+  # modified list. This functions assumes the value is always a List.
+  defp lpop([ head | tail ]),
+    do: { head, tail }
+  defp lpop([ ] = list),
+    do: {  nil, list }
+
+  # A simple right pop for a List to remove the rightmost value and return the
+  # rest as a modified list. This functions assumes the value is always a List.
+  defp rpop([ _head | _tail ] = list),
+    do: { List.last(list), :lists.droplast(list) }
+  defp rpop([ ] = list),
+    do: { nil, list }
 
 end

--- a/test/cachex/actions/invoke_test.exs
+++ b/test/cachex/actions/invoke_test.exs
@@ -22,10 +22,10 @@ defmodule Cachex.Actions.InvokeTest do
     { "list", touched, nil, _val } = Cachex.inspect!(cache, { :record, "list" })
 
     # execute some custom commands
-    lpop1 = Cachex.invoke(cache, :lpop, "list")
-    lpop2 = Cachex.invoke(cache, :lpop, "list")
-    rpop1 = Cachex.invoke(cache, :rpop, "list")
-    rpop2 = Cachex.invoke(cache, :rpop, "list")
+    lpop1 = Cachex.invoke(cache, "list", :lpop)
+    lpop2 = Cachex.invoke(cache, "list", :lpop)
+    rpop1 = Cachex.invoke(cache, "list", :rpop)
+    rpop2 = Cachex.invoke(cache, "list", :rpop)
 
     # verify that all results are as expected
     assert(lpop1 == { :ok, 1 })
@@ -34,14 +34,14 @@ defmodule Cachex.Actions.InvokeTest do
     assert(rpop2 == { :ok, 3 })
 
     # retrieve the raw record again
-    inspect1 = Cachex.inspect(cache, { :record, "list" })
+    inspect1 = Cachex.inspect!(cache, { :record, "list" })
 
     # verify the touched time was unchanged
-    assert(inspect1 == { :ok, { "list", touched, nil, [ ] }})
+    assert(inspect1 == { "list", touched, nil, [ ] })
 
     # pop some extras to test avoiding writes
-    lpop3 = Cachex.invoke(cache, :lpop, "list")
-    rpop3 = Cachex.invoke(cache, :rpop, "list")
+    lpop3 = Cachex.invoke(cache, "list", :lpop)
+    rpop3 = Cachex.invoke(cache, "list", :rpop)
 
     # verify we stayed the same
     assert(lpop3 == { :ok, nil })
@@ -65,7 +65,7 @@ defmodule Cachex.Actions.InvokeTest do
       { :ok, true } = Cachex.set(cache, "list", list)
 
       # retrieve the last value
-      last = Cachex.invoke(cache, :last, "list")
+      last = Cachex.invoke(cache, "list", :last)
 
       # compare with the expected
       assert(last == { :ok, expected })
@@ -96,11 +96,11 @@ defmodule Cachex.Actions.InvokeTest do
     } }
 
     # try to invoke a missing command
-    invoke1 = Cachex.invoke(state, :invoke, "heh")
+    invoke1 = Cachex.invoke(state, "heh", :unknowns)
 
     # try to invoke bad arity commands
-    invoke2 = Cachex.invoke(state, :fake_mod, "heh")
-    invoke3 = Cachex.invoke(state, :fake_ret, "heh")
+    invoke2 = Cachex.invoke(state, "heh", :fake_mod)
+    invoke3 = Cachex.invoke(state, "heh", :fake_ret)
 
     # all should error
     assert(invoke1 == { :error, :invalid_command })

--- a/test/cachex/actions/invoke_test.exs
+++ b/test/cachex/actions/invoke_test.exs
@@ -1,0 +1,59 @@
+defmodule Cachex.Actions.InvokeTest do
+  use CachexCase
+
+  test "invoking custom commands" do
+    # create a list left pop
+    lpop = fn([ head | tail ]) ->
+      { head, tail }
+    end
+
+    # create a list right pop
+    rpop = fn(list) ->
+      { List.last(list), :lists.droplast(list) }
+    end
+
+    # create a test cache
+    cache = Helper.create_cache([
+      commands: [
+        last: { :return, &List.last/1 },
+        lpop: { :modify, lpop },
+        rpop: { :modify, rpop }
+      ]
+    ])
+
+    # set a list inside the cache
+    { :ok, true } = Cachex.set(cache, "list", [ 1, 2, 3, 4, 5 ])
+
+    # retrieve the raw record
+    { "list", touched, nil, _val } = Cachex.inspect!(cache, { :record, "list" })
+
+    # execute some custom commands
+    last1 = Cachex.invoke(cache, :last, "list")
+    lpop1 = Cachex.invoke(cache, :lpop, "list")
+    lpop2 = Cachex.invoke(cache, :lpop, "list")
+    rpop1 = Cachex.invoke(cache, :rpop, "list")
+    rpop2 = Cachex.invoke(cache, :rpop, "list")
+    last2 = Cachex.invoke(cache, :last, "list")
+
+    # verify that all results are as expected
+    assert(last1 == { :ok, 5 })
+    assert(lpop1 == { :ok, 1 })
+    assert(lpop2 == { :ok, 2 })
+    assert(rpop1 == { :ok, 5 })
+    assert(rpop2 == { :ok, 4 })
+    assert(last2 == { :ok, 3 })
+
+    # retrieve the raw record again
+    inspect1 = Cachex.inspect(cache, { :record, "list" })
+
+    # verify the touched time was unchanged
+    assert(inspect1 == { :ok, { "list", touched, nil, [ 3 ] }})
+
+    # try to invoke a missing command
+    invoke1 = Cachex.invoke(cache, :invoke, "heh")
+
+    # it should be an error
+    assert(invoke1 == { :error, :invalid_command })
+  end
+
+end

--- a/test/cachex/commands_test.exs
+++ b/test/cachex/commands_test.exs
@@ -1,0 +1,75 @@
+defmodule Cachex.CommandsTest do
+  use CachexCase
+
+  # This test ensures that we can successfully parse a list of commands into a
+  # Map of commands, ensuring that all commands are valid before doing so. To
+  # check this, we try parse both valid and invalid lists of commands to ensure
+  # that we receive a working Map for the valid lists and an error otherwise.
+  test "parsing a list of commands" do
+    # define some functions
+    fun1 = fn(_) -> [ 1, 2, 3 ] end
+
+    # define valid command lists
+    v_cmds1 = [ ]
+    v_cmds2 = [ lpop: { :return, fun1 } ]
+
+    # define invalid command lists
+    i_cmds1 = [ 1 ]
+    i_cmds2 = [ lpop: 1 ]
+
+    # attempt to validate
+    results1 = Cachex.Commands.parse(v_cmds1)
+    results2 = Cachex.Commands.parse(v_cmds2)
+
+    # the first two should be parsed into maps
+    assert(results1 == { :ok, %{ } })
+    assert(results2 == { :ok, %{ lpop: { :return, fun1 } } })
+
+    # parse the rest
+    results3 = Cachex.Commands.parse(i_cmds1)
+    results4 = Cachex.Commands.parse(i_cmds2)
+
+    # the remaining five are invalid
+    assert(results3 == { :error, :invalid_command })
+    assert(results4 == { :error, :invalid_command })
+  end
+
+  # This test ensures that we can successfully validate a list of commands. To
+  # check this, we validate both valid and invalid lists of commands to ensure
+  # that we receive an `:ok` value on success, and an error on failure.
+  test "validating a list of commands" do
+    # define valid command lists
+    v_cmds1 = [ ]
+    v_cmds2 = [ lpop: { :return, &(&1) } ]
+
+    # define invalid command lists
+    i_cmds1 = [ 1 ]
+    i_cmds2 = [ lpop: 1 ]
+    i_cmds3 = [ lpop: { :tag, &(&1) } ]
+    i_cmds4 = [ lpop: { :return, &({ &1, &2 }) } ]
+    i_cmds5 = nil
+
+    # attempt to validate all
+    results1 = Cachex.Commands.validate(v_cmds1)
+    results2 = Cachex.Commands.validate(v_cmds2)
+
+    # the first two should be ok
+    assert(results1 == :ok)
+    assert(results2 == :ok)
+
+    # validate the rest
+    results3 = Cachex.Commands.validate(i_cmds1)
+    results4 = Cachex.Commands.validate(i_cmds2)
+    results5 = Cachex.Commands.validate(i_cmds3)
+    results6 = Cachex.Commands.validate(i_cmds4)
+    results7 = Cachex.Commands.validate(i_cmds5)
+
+    # the remaining five are invalid
+    assert(results3 == { :error, :invalid_command })
+    assert(results4 == { :error, :invalid_command })
+    assert(results5 == { :error, :invalid_command })
+    assert(results6 == { :error, :invalid_command })
+    assert(results7 == { :error, :invalid_command })
+  end
+
+end

--- a/test/cachex/errors_test.exs
+++ b/test/cachex/errors_test.exs
@@ -6,6 +6,7 @@ defmodule Cachex.ErrorsTest do
   test "error generation and mapping" do
     # define all recognised errors
     errors = [
+      invalid_command:   "Invalid command definition provided",
       invalid_hook:      "Invalid hook definition provided",
       invalid_match:     "Invalid match specification provided",
       invalid_name:      "Invalid cache name provided",

--- a/test/cachex/util_test.exs
+++ b/test/cachex/util_test.exs
@@ -297,6 +297,23 @@ defmodule Cachex.UtilTest do
     assert_in_delta(current, millis, 2)
   end
 
+  # This test just provides basic coverage of the write_mod function, by using
+  # tags to determine the correct Action to use to write a value. We make sure
+  # that the :missing and :new tags define a Set and the others define an Update.
+  test "retrieving a module name to write with" do
+    # ask for some modules
+    result1 = Cachex.Util.write_mod(:new)
+    result2 = Cachex.Util.write_mod(:missing)
+    result3 = Cachex.Util.write_mod(:unknown)
+
+    # the first two should be Set actions
+    assert(result1 == Cachex.Actions.Set)
+    assert(result2 == Cachex.Actions.Set)
+
+    # the third should be an Update
+    assert(result3 == Cachex.Actions.Update)
+  end
+
   # There are several places we wish to fetch all rows from a cache, so this util
   # just generates a spec which takes a return set. All we can do here is check
   # that a specification is correctly generated with and without field indexes.

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -18,7 +18,7 @@ defmodule TestHelper do
   # these callbacks.
 
   # test context
-  use ExUnit.Case
+  require ExUnit.Case
 
   @doc false
   # Schedules a cache to be deleted at the end of the current test context.


### PR DESCRIPTION
This fixes #80.

Rather than implement specific List/Set operations, there is now a new `invoke/4` command which allows the invocation of custom commands to carry out custom actions on a value inside the cache. This currently has limited support (by design), but it may be expanded in future.

As it stands, you can add custom commands to the cache and manually implement any List/Set operations you might want (and anything else).