### PR TITLE
Error when invalid fallbacks are provided

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ elixir:
   - 1.3.4
   - 1.2.6
 otp_release:
-  - 19.2
+  - 19.3
   - 18.3
 before_install:
   - mix local.rebar --force

--- a/lib/cachex/util.ex
+++ b/lib/cachex/util.ex
@@ -65,19 +65,13 @@ defmodule Cachex.Util do
     # pluck out the default fallback options
     %{ state: fb_state, action: fb_def } = fall
 
-    # determine state length
-    fb_len = case fb_state do
-      nil -> 1
-      _na -> 2
-    end
-
     cond do
       # valid provided fallback
-      is_function(fb_fun, fb_len) ->
+      is_function(fb_fun) ->
         fb_state |> do_fallback(key, fb_fun) |> normalize_commit
 
       # valid default fallback
-      is_function(fb_def, fb_len) ->
+      is_function(fb_def) ->
         fb_state |> do_fallback(key, fb_def) |> normalize_commit
 
       # no fallback

--- a/test/cachex/util_test.exs
+++ b/test/cachex/util_test.exs
@@ -83,7 +83,7 @@ defmodule Cachex.UtilTest do
   test "getting a fallback value" do
     # define fallbacks
     fallback1 = %Cachex.Fallback{ action: &String.reverse/1 }
-    fallback2 = %Cachex.Fallback{ state:  true }
+    fallback2 = %Cachex.Fallback{ state: true }
 
     # define a state with and without a default fallback
     state1 = %Cachex.State{ }
@@ -112,11 +112,8 @@ defmodule Cachex.UtilTest do
     # retrieve a missing key with no fallback and a custom default
     result6 = Cachex.Util.get_fallback(state1, "key", nil, 10)
 
-    # retrieve a missing key with an invalid fallback arity
-    result7 = Cachex.Util.get_fallback(state1, "key", &String.split/3)
-
     # retrieve a missing key with a fallback state
-    result8 = Cachex.Util.get_fallback(state3, "key", fn(x, true) ->
+    result7 = Cachex.Util.get_fallback(state3, "key", fn(x, true) ->
       { :commit, String.reverse(x) }
     end)
 
@@ -132,11 +129,13 @@ defmodule Cachex.UtilTest do
     # overloaded default should be returned
     assert(result6 == { :default, 10 })
 
-    # invalid functions should skip to returning the default
-    assert(result7 == { :default, nil })
-
     # custom states should function successfully
-    assert(result8 == { :commit, "yek" })
+    assert(result7 == { :commit, "yek" })
+
+    # verify invalid arity fallbacks crash appropriately
+    assert_raise(BadArityError, fn ->
+      Cachex.Util.get_fallback(state1, "key", &String.split/3)
+    end)
   end
 
   # This test ensures the integrity of the basic option parser provided for use


### PR DESCRIPTION
This fixes #101.

Previously we would silently allow fallbacks with bad arity, but this could lead to subtle bugs. It's better if we just crash on the invalid arity to force the user to notice quickly and address sooner. 